### PR TITLE
Schema Migrations: links, tags, link_tags, link_owners

### DIFF
--- a/internal/db/migrations/00003_create_links.sql
+++ b/internal/db/migrations/00003_create_links.sql
@@ -1,19 +1,15 @@
+-- Governing: SPEC-0002 REQ "Links Table"
 -- +goose Up
--- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS links (
-    id          TEXT PRIMARY KEY,
-    slug        TEXT NOT NULL UNIQUE,
-    url         TEXT NOT NULL,
-    owner_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    description TEXT NOT NULL DEFAULT '',
-    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id TEXT PRIMARY KEY,
+    slug TEXT NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT,
+    description TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX IF NOT EXISTS links_slug_idx ON links(slug);
-CREATE INDEX IF NOT EXISTS links_owner_idx ON links(owner_id);
--- +goose StatementEnd
+CREATE UNIQUE INDEX IF NOT EXISTS idx_links_slug ON links(slug);
 
 -- +goose Down
--- +goose StatementBegin
 DROP TABLE IF EXISTS links;
--- +goose StatementEnd

--- a/internal/db/migrations/00004_create_tags.sql
+++ b/internal/db/migrations/00004_create_tags.sql
@@ -1,0 +1,12 @@
+-- Governing: SPEC-0002 REQ "Tags Table"
+-- +goose Up
+CREATE TABLE IF NOT EXISTS tags (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_slug ON tags(slug);
+
+-- +goose Down
+DROP TABLE IF EXISTS tags;

--- a/internal/db/migrations/00005_create_link_tags.sql
+++ b/internal/db/migrations/00005_create_link_tags.sql
@@ -1,0 +1,10 @@
+-- Governing: SPEC-0002 REQ "Link Tags Join Table"
+-- +goose Up
+CREATE TABLE IF NOT EXISTS link_tags (
+    link_id TEXT NOT NULL REFERENCES links(id) ON DELETE CASCADE,
+    tag_id TEXT NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (link_id, tag_id)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS link_tags;

--- a/internal/db/migrations/00006_create_link_owners.sql
+++ b/internal/db/migrations/00006_create_link_owners.sql
@@ -1,0 +1,11 @@
+-- Governing: SPEC-0002 REQ "Link Owners Join Table", ADR-0005
+-- +goose Up
+CREATE TABLE IF NOT EXISTS link_owners (
+    link_id TEXT NOT NULL REFERENCES links(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    is_primary INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (link_id, user_id)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS link_owners;


### PR DESCRIPTION
## Summary

- **Replaced** `00003_create_links.sql` to remove the incorrect `owner_id` column, making it compliant with SPEC-0002
- **Added** `00004_create_tags.sql` — tags table with unique slug index
- **Added** `00005_create_link_tags.sql` — many-to-many join table between links and tags
- **Added** `00006_create_link_owners.sql` — many-to-many ownership join table with `is_primary` flag (ADR-0005)

Pure database migration layer — no application logic changes.

## Test plan

- [ ] Run `joe-links migrate` with a fresh SQLite database and verify all tables are created
- [ ] Verify `links` table has no `owner_id` column
- [ ] Verify foreign key constraints on `link_tags` and `link_owners`
- [ ] Verify `is_primary` defaults to 0 on `link_owners`
- [ ] Run goose down/up cycle to verify rollback works

Closes #9
Part of #2 (epic)
Governing: SPEC-0002 REQ "Links Table", "Tags Table", "Link Tags Join Table", ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)