### PR TITLE
Ownership Model & Authorization

### DIFF
--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -1,0 +1,11 @@
+// Governing: SPEC-0002 REQ "Authorization Based on Ownership", ADR-0005
+package store
+
+// IsOwnerOrAdmin returns true if userID appears in link_owners for linkID, OR role == "admin".
+// Governing: SPEC-0002 REQ "Authorization Based on Ownership"
+func IsOwnerOrAdmin(ownerStore *OwnershipStore, linkID, userID, role string) (bool, error) {
+	if role == "admin" {
+		return true, nil
+	}
+	return ownerStore.IsOwner(linkID, userID)
+}

--- a/internal/store/ownership.go
+++ b/internal/store/ownership.go
@@ -1,0 +1,100 @@
+// Governing: SPEC-0002 REQ "Multi-Ownership via link_owners", "Authorization Based on Ownership", ADR-0005
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var (
+	ErrNotOwner              = errors.New("user is not an owner of this link")
+	ErrPrimaryOwnerImmutable = errors.New("primary owner cannot be removed")
+	ErrAlreadyOwner          = errors.New("user is already an owner of this link")
+)
+
+// OwnershipStore manages link_owners relationships.
+// Governing: SPEC-0002 REQ "Multi-Ownership via link_owners", ADR-0005
+type OwnershipStore struct {
+	db *sqlx.DB
+}
+
+func NewOwnershipStore(db *sqlx.DB) *OwnershipStore {
+	return &OwnershipStore{db: db}
+}
+
+// AddOwner adds userID as a co-owner (is_primary=false) of linkID.
+// Returns ErrAlreadyOwner if already present.
+func (s *OwnershipStore) AddOwner(linkID, userID string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO link_owners (link_id, user_id, is_primary) VALUES (?, ?, 0)`,
+		linkID, userID,
+	)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return ErrAlreadyOwner
+		}
+		return err
+	}
+	return nil
+}
+
+// AddPrimaryOwner adds userID as the primary owner during link creation.
+func (s *OwnershipStore) AddPrimaryOwner(linkID, userID string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO link_owners (link_id, user_id, is_primary) VALUES (?, ?, 1)`,
+		linkID, userID,
+	)
+	return err
+}
+
+// RemoveOwner removes userID from link_owners. Returns ErrPrimaryOwnerImmutable if is_primary=1.
+func (s *OwnershipStore) RemoveOwner(linkID, userID string) error {
+	var isPrimary bool
+	err := s.db.QueryRow(
+		`SELECT is_primary FROM link_owners WHERE link_id = ? AND user_id = ?`,
+		linkID, userID,
+	).Scan(&isPrimary)
+	if err == sql.ErrNoRows {
+		return ErrNotOwner
+	}
+	if err != nil {
+		return err
+	}
+	if isPrimary {
+		return ErrPrimaryOwnerImmutable
+	}
+	_, err = s.db.Exec(`DELETE FROM link_owners WHERE link_id = ? AND user_id = ?`, linkID, userID)
+	return err
+}
+
+// IsOwner returns true if userID is in link_owners for linkID.
+func (s *OwnershipStore) IsOwner(linkID, userID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		`SELECT COUNT(*) FROM link_owners WHERE link_id = ? AND user_id = ?`,
+		linkID, userID,
+	).Scan(&count)
+	return count > 0, err
+}
+
+// ListOwners returns all user IDs that own linkID.
+func (s *OwnershipStore) ListOwners(linkID string) ([]string, error) {
+	var owners []string
+	err := s.db.Select(&owners, `SELECT user_id FROM link_owners WHERE link_id = ?`, linkID)
+	return owners, err
+}
+
+// isUniqueConstraintError checks whether err indicates a unique constraint violation.
+// Works across SQLite, PostgreSQL, and MySQL.
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") || // SQLite & PostgreSQL
+		strings.Contains(msg, "duplicate key") || // PostgreSQL
+		strings.Contains(msg, "duplicate entry") // MySQL
+}


### PR DESCRIPTION
## Summary
- Adds `OwnershipStore` with `AddOwner`, `AddPrimaryOwner`, `RemoveOwner`, `IsOwner`, and `ListOwners` operations for managing the `link_owners` table
- Enforces the primary-owner invariant (immutable) at the application layer — primary owners cannot be removed
- Adds `IsOwnerOrAdmin` authorization helper that grants access if user is an owner OR has the admin role
- Unique constraint violation detection works across SQLite, PostgreSQL, and MySQL

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Integration test: create a link, verify primary owner is set
- [ ] Integration test: add co-owner, verify `IsOwner` returns true
- [ ] Integration test: attempt to remove primary owner, verify `ErrPrimaryOwnerImmutable`
- [ ] Integration test: remove co-owner, verify removal succeeds
- [ ] Integration test: `IsOwnerOrAdmin` returns true for admin role regardless of ownership

Closes #11
Part of #2 (epic)
Governing: SPEC-0002 REQ "Multi-Ownership via link_owners", "Authorization Based on Ownership", ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)