### PR TITLE
OIDC Authentication & Session Management

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -135,6 +135,7 @@ func setPreAuthCookie(w http.ResponseWriter, name, value string) {
 		Path:     "/",
 		MaxAge:   300, // 5 minutes
 		HttpOnly: true,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -32,6 +32,7 @@ func NewSessionManager(db *sqlx.DB, driver string, lifetime time.Duration) *scs.
 	}
 	sm.Lifetime = lifetime
 	sm.Cookie.HttpOnly = true
+	sm.Cookie.Secure = true
 	sm.Cookie.SameSite = http.SameSiteLaxMode
 	return sm
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Governing: SPEC-0001 REQ "CLI Entrypoint", ADR-0004
+// Governing: SPEC-0001 REQ "CLI Entrypoint", "OIDC-Only Authentication", "Server-Side Sessions", ADR-0003, ADR-0004
 package config
 
 import (


### PR DESCRIPTION
## Summary

Verifies and fixes the OIDC authentication, local user records, and server-side session management implementation per SPEC-0001 and ADR-0003.

- **Fix**: Added missing `Secure: true` flag on SCS session cookies and pre-auth OIDC cookies (state, PKCE verifier, redirect) per REQ "Server-Side Sessions"
- **OIDC auth flow**: PKCE + state validation, ID token verification, proper 400/401 error responses
- **User records**: UPSERT on `(provider, subject)` preserves existing `role`; `JOE_ADMIN_EMAIL` bootstrap grants `admin` on first login
- **Sessions**: SCS with DB-backed store (sqlite3/mysql/postgres), `JOE_SESSION_LIFETIME` (default 30 days), stores only `user_id` and `role`
- Added governing comment to `config.go`

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] Login flow redirects to OIDC provider with `state` and `code_challenge` params
- [ ] Callback with mismatched state returns 400
- [ ] Callback with invalid code returns 401
- [ ] Successful callback creates session with `user_id` and `role` only
- [ ] First login with `JOE_ADMIN_EMAIL` match sets role to `admin`
- [ ] Returning user login preserves existing `role`
- [ ] POST `/auth/logout` destroys session and clears cookie
- [ ] Session cookies have `HttpOnly`, `Secure`, and `SameSite=Lax`
- [ ] Session expires after `JOE_SESSION_LIFETIME`

Closes #6
Part of #1 (epic)
Governing: SPEC-0001 REQ "OIDC-Only Authentication", "Local User Records", "Server-Side Sessions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)