### PR TITLE
Base Layout: Anti-Flash Script & Cookie-Based Theme Render

### DIFF
--- a/internal/handler/dashboard.go
+++ b/internal/handler/dashboard.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0001 REQ "Short Link Management", REQ "HTMX Hypermedia Interactions", ADR-0001
+// Governing: SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
 package handler
 
 import (
@@ -10,6 +11,7 @@ import (
 
 // DashboardPage is the template data for the dashboard view.
 type DashboardPage struct {
+	BasePage
 	User  *store.User
 	Links []*store.Link
 	Flash *Flash
@@ -42,7 +44,7 @@ func (h *DashboardHandler) Show(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := DashboardPage{User: user, Links: links}
+	data := DashboardPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Links: links}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return

--- a/internal/handler/links.go
+++ b/internal/handler/links.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0001 REQ "Short Link Management", REQ "HTMX Hypermedia Interactions", ADR-0001
+// Governing: SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
 package handler
 
 import (
@@ -35,6 +36,7 @@ type LinkForm struct {
 
 // LinkFormPage is the template data for the new/edit link forms.
 type LinkFormPage struct {
+	BasePage
 	User  *store.User
 	Link  *store.Link
 	Form  LinkForm
@@ -58,7 +60,7 @@ func NewLinksHandler(ls *store.LinkStore, os *store.OwnershipStore) *LinksHandle
 func (h *LinksHandler) New(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	form := LinkForm{Slug: r.URL.Query().Get("slug")}
-	data := LinkFormPage{User: user, Form: form}
+	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return
@@ -82,7 +84,7 @@ func (h *LinksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := store.ValidateSlugFormat(form.Slug); err != nil {
-		data := LinkFormPage{User: user, Form: form, Error: err.Error()}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: err.Error()}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return
@@ -91,13 +93,13 @@ func (h *LinksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if isReservedSlug(form.Slug) {
-		render(w, "new.html", LinkFormPage{User: user, Form: form, Error: "That slug uses a reserved prefix (auth, static, dashboard, admin)."})
+		render(w, "new.html", LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: "That slug uses a reserved prefix (auth, static, dashboard, admin)."})
 		return
 	}
 
 	_, err := h.links.Create(r.Context(), form.Slug, form.URL, user.ID, "", form.Description)
 	if err != nil {
-		data := LinkFormPage{User: user, Form: form, Error: "That slug is already taken. Choose a different one."}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: "That slug is already taken. Choose a different one."}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return
@@ -133,7 +135,7 @@ func (h *LinksHandler) Edit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := LinkFormPage{User: user, Link: link}
+	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Link: link}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return
@@ -174,7 +176,7 @@ func (h *LinksHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Governing: SPEC-0001 REQ "Short Link Management" — slug is immutable, not updated here.
 	_, err = h.links.Update(r.Context(), id, form.URL, "", form.Description)
 	if err != nil {
-		data := LinkFormPage{User: user, Link: link, Form: form, Error: "Update failed."}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Link: link, Form: form, Error: "Update failed."}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return

--- a/internal/handler/resolve.go
+++ b/internal/handler/resolve.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0001 REQ "Short Link Resolution", REQ "HTMX Hypermedia Interactions", ADR-0001
+// Governing: SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
 package handler
 
 import (
@@ -20,6 +21,7 @@ func NewResolveHandler(ls *store.LinkStore) *ResolveHandler {
 }
 
 type notFoundPage struct {
+	BasePage
 	User  *store.User
 	Slug  string
 	Flash *Flash
@@ -33,7 +35,7 @@ func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		user := auth.UserFromContext(r.Context())
 		w.WriteHeader(http.StatusNotFound)
-		data := notFoundPage{User: user, Slug: slug}
+		data := notFoundPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Slug: slug}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return

--- a/internal/handler/templates.go
+++ b/internal/handler/templates.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0001 REQ "HTMX Hypermedia Interactions", REQ "DaisyUI and Tailwind CSS", ADR-0001
+// Governing: SPEC-0003 REQ "System-Preference Default", SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
 package handler
 
 import (
@@ -7,6 +8,26 @@ import (
 
 	"github.com/joestump/joe-links/web"
 )
+
+// BasePage carries layout-level data available to every template.
+// Governing: SPEC-0003 REQ "Theme Persistence via Cookie"
+type BasePage struct {
+	Theme string // "joe-light", "joe-dark", or "" (let inline script decide)
+}
+
+// themeFromRequest reads the "theme" cookie. Returns "" if absent or invalid,
+// so the server omits data-theme and lets the anti-flash inline script handle it.
+// Governing: SPEC-0003 REQ "Theme Persistence via Cookie"
+func themeFromRequest(r *http.Request) string {
+	c, err := r.Cookie("theme")
+	if err != nil {
+		return ""
+	}
+	if c.Value == "joe-light" || c.Value == "joe-dark" {
+		return c.Value
+	}
+	return ""
+}
 
 var templates *template.Template
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en"{{if .Theme}} data-theme="{{.Theme}}"{{end}}>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{block "title" .}}Joe Links{{end}}</title>
+    <!-- Governing: SPEC-0003 REQ "System-Preference Default" — anti-flash inline script, must precede stylesheets -->
+    <script>(function(){var t=document.cookie.match(/theme=([^;]+)/);var theme=t?decodeURIComponent(t[1]):(window.matchMedia('(prefers-color-scheme: dark)').matches?'joe-dark':'joe-light');if(theme==='joe-light'||theme==='joe-dark'){document.documentElement.setAttribute('data-theme',theme)}})()</script>
     <link rel="stylesheet" href="/static/css/app.css">
     <script src="/static/js/htmx.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary

Implements SPEC-0003 REQ "System-Preference Default" and REQ "Theme Persistence via Cookie".

- Adds inline anti-flash `<script>` to `base.html` `<head>` before any stylesheet, reading the `theme` cookie or falling back to `prefers-color-scheme`
- Introduces `BasePage` struct with `Theme` field, embedded in all page data structs
- Adds `themeFromRequest()` helper to read and validate the `theme` cookie
- Threads theme cookie reading through all page handlers (dashboard, links, resolve)

## Test plan

- [ ] Verify no flash of unstyled/wrong-theme content on page load
- [ ] Set `theme=joe-dark` cookie manually and confirm `data-theme="joe-dark"` renders on `<html>`
- [ ] Clear cookie and confirm `prefers-color-scheme` media query drives theme selection
- [ ] Verify `data-theme` is omitted from `<html>` when no cookie is set (inline script handles it)
- [ ] Confirm `go build ./...` passes cleanly

Closes #24
Part of #22 (epic)
Governing: SPEC-0003 REQ "System-Preference Default", SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006