### PR TITLE
Theme Toggle: Endpoint & Navbar Control

### DIFF
--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0001 REQ "Go HTTP Server", "Role-Based Access Control", "Short Link Resolution", ADR-0001, ADR-0003
+// Governing: SPEC-0003 REQ "HTMX Theme Endpoint", ADR-0006
 package handler
 
 import (
@@ -44,6 +45,11 @@ func NewRouter(deps Deps) http.Handler {
 	r.Get("/auth/login", deps.AuthHandlers.Login)
 	r.Get("/auth/callback", deps.AuthHandlers.Callback)
 	r.Post("/auth/logout", deps.AuthHandlers.Logout)
+
+	// Theme toggle — no auth required, must precede auth group.
+	// Governing: SPEC-0003 REQ "HTMX Theme Endpoint"
+	themeHandler := NewThemeHandler()
+	r.Post("/dashboard/theme", themeHandler.Toggle)
 
 	// Authenticated routes
 	dashboard := NewDashboardHandler(deps.LinkStore)

--- a/internal/handler/theme.go
+++ b/internal/handler/theme.go
@@ -1,0 +1,50 @@
+// Governing: SPEC-0003 REQ "HTMX Theme Endpoint", SPEC-0003 REQ "Theme Toggle Control",
+// SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ThemeHandler handles the theme toggle endpoint.
+type ThemeHandler struct{}
+
+// NewThemeHandler creates a new ThemeHandler.
+func NewThemeHandler() *ThemeHandler {
+	return &ThemeHandler{}
+}
+
+// Toggle handles POST /dashboard/theme.
+// No auth required — sets the theme cookie and returns HX-Trigger for client-side swap.
+// Governing: SPEC-0003 REQ "HTMX Theme Endpoint"
+func (h *ThemeHandler) Toggle(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	theme := r.FormValue("theme")
+	if theme != "joe-light" && theme != "joe-dark" {
+		http.Error(w, "invalid theme", http.StatusBadRequest)
+		return
+	}
+
+	// Persist via cookie (non-HttpOnly so the anti-flash script can read it).
+	// Governing: SPEC-0003 REQ "Theme Persistence via Cookie"
+	http.SetCookie(w, &http.Cookie{
+		Name:     "theme",
+		Value:    theme,
+		Path:     "/",
+		MaxAge:   365 * 24 * 60 * 60, // 1 year
+		SameSite: http.SameSiteLaxMode,
+		HttpOnly: false,
+	})
+
+	// Return HX-Trigger for client-side data-theme swap.
+	// Governing: SPEC-0003 REQ "Theme Toggle Control"
+	trigger, _ := json.Marshal(map[string]any{
+		"themeChanged": map[string]string{"theme": theme},
+	})
+	w.Header().Set("HX-Trigger", string(trigger))
+	w.WriteHeader(http.StatusOK)
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -9,7 +9,8 @@
     <link rel="stylesheet" href="/static/css/app.css">
     <script src="/static/js/htmx.min.js"></script>
 </head>
-<body class="min-h-screen bg-base-100">
+<body class="min-h-screen bg-base-100"
+      hx-on:themeChanged="document.documentElement.setAttribute('data-theme',event.detail.theme);document.getElementById('theme-toggle-icon').textContent=event.detail.theme==='joe-dark'?'☀️':'🌙'">
 
 <nav class="navbar bg-base-200 shadow-sm px-4">
     <div class="navbar-start">
@@ -18,6 +19,14 @@
         </a>
     </div>
     <div class="navbar-end gap-2">
+        <!-- Governing: SPEC-0003 REQ "Theme Toggle Control" — sun when dark, moon when light -->
+        <button id="theme-toggle"
+                class="btn btn-ghost btn-circle"
+                hx-post="/dashboard/theme"
+                hx-vals='js:{theme: document.documentElement.getAttribute("data-theme") === "joe-dark" ? "joe-light" : "joe-dark"}'
+                hx-swap="none">
+            <span id="theme-toggle-icon">{{if eq .Theme "joe-dark"}}☀️{{else}}🌙{{end}}</span>
+        </button>
         {{if .User}}
         <span class="text-sm text-base-content/70">{{.User.DisplayName}}</span>
         <form method="POST" action="/auth/logout">


### PR DESCRIPTION
## Summary

- Adds `POST /dashboard/theme` handler that validates theme value, sets a persistent cookie, and returns `HX-Trigger` for client-side swap
- Adds sun/moon toggle button to the navbar using HTMX (`hx-post`, `hx-vals`, `hx-on::after-request`)
- Threads `Theme` field through all page structs, read from the `theme` cookie on each request
- Sets `data-theme` on `<html>` element server-side from cookie value

Closes #26
Part of #22 (epic)
Governing: SPEC-0003 REQ "Theme Toggle Control", SPEC-0003 REQ "HTMX Theme Endpoint", ADR-0006

## Test plan

- [ ] `POST /dashboard/theme` with `theme=joe-dark` returns 200, sets `theme=joe-dark` cookie, and includes `HX-Trigger` header
- [ ] `POST /dashboard/theme` with `theme=joe-light` returns 200, sets `theme=joe-light` cookie, and includes `HX-Trigger` header
- [ ] `POST /dashboard/theme` with `theme=invalid` returns 400 and does not set cookie
- [ ] Navbar shows moon icon when theme is `joe-light`, sun icon when `joe-dark`
- [ ] Clicking toggle swaps theme without full page reload
- [ ] Cookie persists across page refreshes — server renders correct `data-theme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)