### PR TITLE
Custom DaisyUI Pastel Theme Definitions

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,11 +15,11 @@ module.exports = {
       {
         "joe-light": {
           "primary": "#c084fc",
-          "primary-content": "#ffffff",
+          "primary-content": "#160030",
           "secondary": "#fb923c",
-          "secondary-content": "#ffffff",
+          "secondary-content": "#000000",
           "accent": "#34d399",
-          "accent-content": "#ffffff",
+          "accent-content": "#000000",
           "neutral": "#6b7280",
           "neutral-content": "#ffffff",
           "base-100": "#ffffff",
@@ -39,11 +39,11 @@ module.exports = {
       {
         "joe-dark": {
           "primary": "#a855f7",
-          "primary-content": "#ffffff",
+          "primary-content": "#160030",
           "secondary": "#f97316",
-          "secondary-content": "#ffffff",
+          "secondary-content": "#000000",
           "accent": "#10b981",
-          "accent-content": "#ffffff",
+          "accent-content": "#000000",
           "neutral": "#9ca3af",
           "neutral-content": "#000000",
           "base-100": "#111111",


### PR DESCRIPTION
## Summary

- Defines `joe-light` and `joe-dark` custom DaisyUI themes in `tailwind.config.js` with full pastel color palettes from ADR-0006
- Fixes WCAG AA contrast violations: changed `primary-content`, `secondary-content`, and `accent-content` from white to dark values that meet the 4.5:1 minimum contrast ratio in both themes
- No built-in DaisyUI themes are enabled; only custom themes are defined

## WCAG AA Verification

| Pairing | joe-light | joe-dark | Threshold |
|---------|-----------|----------|-----------|
| primary-content on primary | 7.38:1 | 4.93:1 | 4.5:1 |
| secondary-content on secondary | 9.28:1 | 7.49:1 | 4.5:1 |
| accent-content on accent | 10.92:1 | 8.28:1 | 4.5:1 |
| base-content on base-100 | 21.00:1 | 18.88:1 | 4.5:1 |

## Test plan

- [ ] Set `data-theme="joe-light"` on `<html>` and verify DaisyUI components render with lilac primary, peach secondary, mint accent
- [ ] Set `data-theme="joe-dark"` on `<html>` and verify purple primary, orange secondary, emerald accent
- [ ] Verify text on primary/secondary/accent buttons is legible (dark text on colored backgrounds)
- [ ] Run automated contrast checker against both theme palettes

Closes #13
Part of #3 (epic)
Governing: SPEC-0003 REQ "Custom DaisyUI Themes", "WCAG AA Color Contrast", ADR-0006