### PR TITLE
Optimize anti-flash script to under 200 bytes

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{block "title" .}}Joe Links{{end}}</title>
     <!-- Governing: SPEC-0003 REQ "System-Preference Default" — anti-flash inline script, must precede stylesheets -->
-    <script>(function(){var t=document.cookie.match(/theme=([^;]+)/);var theme=t?decodeURIComponent(t[1]):(window.matchMedia('(prefers-color-scheme: dark)').matches?'joe-dark':'joe-light');if(theme==='joe-light'||theme==='joe-dark'){document.documentElement.setAttribute('data-theme',theme)}})()</script>
+    <script>!function(){var c=document.cookie.match(/theme=(joe-(?:light|dark))/);document.documentElement.dataset.theme=c?c[1]:matchMedia("(prefers-color-scheme:dark)").matches?"joe-dark":"joe-light"}()</script>
     <link rel="stylesheet" href="/static/css/app.css">
     <script src="/static/js/htmx.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary

- Minifies the inline anti-flash theme-detection script in `base.html` from 283 bytes to 191 bytes, meeting the SPEC-0003 requirement of < 200 bytes
- Validates the cookie value via regex (`joe-light|joe-dark`) in one step, eliminating the separate validation check
- Uses `dataset.theme` instead of `setAttribute` and drops unnecessary `decodeURIComponent` and `window.` prefix

## How it works

The script runs synchronously in `<head>` before stylesheets load:
1. Reads the `theme` cookie — only accepts `joe-light` or `joe-dark`
2. Falls back to `matchMedia('(prefers-color-scheme:dark)')` for system preference
3. Sets `data-theme` on `<html>` before first paint — no flash

## Test plan

- [ ] Visit with no `theme` cookie + OS dark mode: page renders `joe-dark` without flash
- [ ] Visit with no `theme` cookie + OS light mode: page renders `joe-light` without flash
- [ ] Visit with `theme=joe-dark` cookie: page renders `joe-dark`
- [ ] Visit with `theme=joe-light` cookie: page renders `joe-light`
- [ ] Visit with `theme=invalid` cookie: falls back to system preference
- [ ] Verify script tag is < 200 bytes in page source

Closes #14
Part of #3 (epic)
Governing: SPEC-0003 REQ "System-Preference Default", ADR-0006