### PR TITLE
Theme Toggle, Cookie Persistence & HTMX Endpoint

### DIFF
--- a/internal/handler/theme.go
+++ b/internal/handler/theme.go
@@ -1,5 +1,4 @@
-// Governing: SPEC-0003 REQ "HTMX Theme Endpoint", SPEC-0003 REQ "Theme Toggle Control",
-// SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
+// Governing: SPEC-0003 REQ "Theme Toggle Control", "Theme Persistence via Cookie", "HTMX Theme Endpoint", ADR-0006
 package handler
 
 import (


### PR DESCRIPTION
## Summary

Verifies and finalizes the theme toggle control, cookie persistence, and `POST /dashboard/theme` HTMX endpoint.

- **Theme Toggle Control**: Sun/moon icon button in navbar, toggles via `hx-post="/dashboard/theme"` with no page reload
- **Theme Persistence via Cookie**: `theme` cookie with `SameSite=Lax`, `Max-Age=31536000`, `Path=/`, non-HttpOnly; server reads cookie and sets `data-theme` on `<html>`
- **HTMX Theme Endpoint**: `POST /dashboard/theme` (no auth required), validates `joe-light`/`joe-dark`, sets cookie, returns `HX-Trigger: {"themeChanged": {"theme": "..."}}`, 400 for invalid values
- Consolidated governing comment format in `theme.go`

Closes #15
Part of #3 (epic)
Governing: SPEC-0003 REQ "Theme Toggle Control", "Theme Persistence via Cookie", "HTMX Theme Endpoint"