### PR TITLE
Router Setup, Middleware Groups & Shared Base Layout

### DIFF
--- a/cmd/joe-links/serve.go
+++ b/cmd/joe-links/serve.go
@@ -56,6 +56,7 @@ func newServeCmd() *cobra.Command {
 				AuthMiddleware: authMiddleware,
 				LinkStore:      linkStore,
 				OwnershipStore: ownershipStore,
+				TagStore:       tagStore,
 			})
 
 			log.Printf("listening on %s", cfg.HTTP.Addr)

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1,0 +1,40 @@
+// Governing: SPEC-0004 REQ "Admin Dashboard", ADR-0007
+package handler
+
+import (
+	"net/http"
+
+	"github.com/joestump/joe-links/internal/auth"
+)
+
+// AdminHandler serves admin views.
+type AdminHandler struct{}
+
+// NewAdminHandler creates a new AdminHandler.
+func NewAdminHandler() *AdminHandler { return &AdminHandler{} }
+
+// Dashboard renders the admin overview.
+func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := BasePage{Theme: themeFromRequest(r), User: user}
+	render(w, "admin/dashboard.html", data)
+}
+
+// Users renders the user management list.
+func (h *AdminHandler) Users(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := BasePage{Theme: themeFromRequest(r), User: user}
+	render(w, "admin/users.html", data)
+}
+
+// UpdateRole handles PUT /admin/users/{id}/role.
+func (h *AdminHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+// Links renders the admin link list.
+func (h *AdminHandler) Links(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := BasePage{Theme: themeFromRequest(r), User: user}
+	render(w, "admin/links.html", data)
+}

--- a/internal/handler/coowners.go
+++ b/internal/handler/coowners.go
@@ -1,0 +1,82 @@
+// Governing: SPEC-0004 REQ "Co-Owner Management", ADR-0007
+package handler
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// AddOwner handles POST /dashboard/links/{id}/owners.
+func (h *LinksHandler) AddOwner(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	allowed, err := store.IsOwnerOrAdmin(h.owns, link.ID, user.ID, user.Role)
+	if err != nil || !allowed {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+// RemoveOwner handles DELETE /dashboard/links/{id}/owners/{uid}.
+func (h *LinksHandler) RemoveOwner(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	allowed, err := store.IsOwnerOrAdmin(h.owns, link.ID, user.ID, user.Role)
+	if err != nil || !allowed {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	_ = chi.URLParam(r, "uid")
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+
+// Detail handles GET /dashboard/links/{id}.
+func (h *LinksHandler) Detail(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	allowed, err := store.IsOwnerOrAdmin(h.owns, link.ID, user.ID, user.Role)
+	if err != nil || !allowed {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Link: link}
+	if isHTMX(r) {
+		renderFragment(w, "content", data)
+		return
+	}
+	render(w, "links/detail.html", data)
+}
+
+// ValidateSlug handles GET /dashboard/links/validate-slug?slug=...
+func (h *LinksHandler) ValidateSlug(w http.ResponseWriter, r *http.Request) {
+	slug := r.URL.Query().Get("slug")
+	w.Header().Set("Content-Type", "text/html")
+	if err := store.ValidateSlugFormat(slug); err != nil {
+		w.Write([]byte(`<span class="text-error text-xs">` + err.Error() + `</span>`))
+		return
+	}
+	if _, err := h.links.GetBySlug(r.Context(), slug); err == nil {
+		w.Write([]byte(`<span class="text-error text-xs">Slug already taken</span>`))
+		return
+	}
+	w.Write([]byte(`<span class="text-success text-xs">Available!</span>`))
+}

--- a/internal/handler/dashboard.go
+++ b/internal/handler/dashboard.go
@@ -44,7 +44,7 @@ func (h *DashboardHandler) Show(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := DashboardPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Links: links}
+	data := DashboardPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Links: links}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return

--- a/internal/handler/landing.go
+++ b/internal/handler/landing.go
@@ -1,0 +1,24 @@
+// Governing: SPEC-0004 REQ "Landing Page", ADR-0007
+package handler
+
+import (
+	"net/http"
+
+	"github.com/joestump/joe-links/internal/auth"
+)
+
+// LandingHandler serves the public landing page.
+type LandingHandler struct{}
+
+// NewLandingHandler creates a new LandingHandler.
+func NewLandingHandler() *LandingHandler { return &LandingHandler{} }
+
+// Index serves GET /. Authenticated users are redirected to /dashboard.
+func (h *LandingHandler) Index(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user != nil {
+		http.Redirect(w, r, "/dashboard", http.StatusFound)
+		return
+	}
+	render(w, "landing.html", BasePage{Theme: themeFromRequest(r)})
+}

--- a/internal/handler/links.go
+++ b/internal/handler/links.go
@@ -60,7 +60,7 @@ func NewLinksHandler(ls *store.LinkStore, os *store.OwnershipStore) *LinksHandle
 func (h *LinksHandler) New(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	form := LinkForm{Slug: r.URL.Query().Get("slug")}
-	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form}
+	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Form: form}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return
@@ -84,7 +84,7 @@ func (h *LinksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := store.ValidateSlugFormat(form.Slug); err != nil {
-		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: err.Error()}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Form: form, Error: err.Error()}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return
@@ -93,13 +93,13 @@ func (h *LinksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if isReservedSlug(form.Slug) {
-		render(w, "new.html", LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: "That slug uses a reserved prefix (auth, static, dashboard, admin)."})
+		render(w, "new.html", LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Form: form, Error: "That slug uses a reserved prefix (auth, static, dashboard, admin)."})
 		return
 	}
 
 	_, err := h.links.Create(r.Context(), form.Slug, form.URL, user.ID, "", form.Description)
 	if err != nil {
-		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Form: form, Error: "That slug is already taken. Choose a different one."}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Form: form, Error: "That slug is already taken. Choose a different one."}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return
@@ -135,7 +135,7 @@ func (h *LinksHandler) Edit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Link: link}
+	data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Link: link}
 	if isHTMX(r) {
 		renderFragment(w, "content", data)
 		return
@@ -176,7 +176,7 @@ func (h *LinksHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Governing: SPEC-0001 REQ "Short Link Management" — slug is immutable, not updated here.
 	_, err = h.links.Update(r.Context(), id, form.URL, "", form.Description)
 	if err != nil {
-		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Link: link, Form: form, Error: "Update failed."}
+		data := LinkFormPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Link: link, Form: form, Error: "Update failed."}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return

--- a/internal/handler/resolve.go
+++ b/internal/handler/resolve.go
@@ -35,7 +35,7 @@ func (h *ResolveHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		user := auth.UserFromContext(r.Context())
 		w.WriteHeader(http.StatusNotFound)
-		data := notFoundPage{BasePage: BasePage{Theme: themeFromRequest(r)}, User: user, Slug: slug}
+		data := notFoundPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Slug: slug}
 		if isHTMX(r) {
 			renderFragment(w, "content", data)
 			return

--- a/internal/handler/tags.go
+++ b/internal/handler/tags.go
@@ -1,0 +1,37 @@
+// Governing: SPEC-0004 REQ "Tag Browser", ADR-0007
+package handler
+
+import (
+	"net/http"
+
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// TagsHandler serves tag browsing views.
+type TagsHandler struct {
+	tags *store.TagStore
+}
+
+// NewTagsHandler creates a new TagsHandler.
+func NewTagsHandler(ts *store.TagStore) *TagsHandler { return &TagsHandler{tags: ts} }
+
+// Index renders all tags with counts.
+func (h *TagsHandler) Index(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := BasePage{Theme: themeFromRequest(r), User: user}
+	render(w, "tags/index.html", data)
+}
+
+// Detail renders links for a specific tag.
+func (h *TagsHandler) Detail(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := BasePage{Theme: themeFromRequest(r), User: user}
+	render(w, "tags/detail.html", data)
+}
+
+// Suggest returns tag autocomplete results.
+func (h *TagsHandler) Suggest(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html")
+	w.Write([]byte(""))
+}

--- a/internal/handler/templates.go
+++ b/internal/handler/templates.go
@@ -6,13 +6,16 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/joestump/joe-links/internal/store"
 	"github.com/joestump/joe-links/web"
 )
 
 // BasePage carries layout-level data available to every template.
 // Governing: SPEC-0003 REQ "Theme Persistence via Cookie"
+// Governing: SPEC-0004 REQ "Shared Base Layout" — User enables conditional admin nav link
 type BasePage struct {
-	Theme string // "joe-light", "joe-dark", or "" (let inline script decide)
+	Theme string      // "joe-light", "joe-dark", or "" (let inline script decide)
+	User  *store.User // nil for unauthenticated pages
 }
 
 // themeFromRequest reads the "theme" cookie. Returns "" if absent or invalid,
@@ -38,6 +41,8 @@ func init() {
 		"templates/partials/*.html",
 		"templates/pages/*.html",
 		"templates/pages/links/*.html",
+		"templates/pages/admin/*.html",
+		"templates/pages/tags/*.html",
 	)
 	if err != nil {
 		panic("failed to parse templates: " + err.Error())

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -12,43 +12,71 @@
 <body class="min-h-screen bg-base-100"
       hx-on:themeChanged="document.documentElement.setAttribute('data-theme',event.detail.theme);document.getElementById('theme-toggle-icon').textContent=event.detail.theme==='joe-dark'?'☀️':'🌙'">
 
+{{if .User}}
+<!-- Governing: SPEC-0004 REQ "Shared Base Layout" — navbar with nav links, conditional Admin, user dropdown -->
 <nav class="navbar bg-base-200 shadow-sm px-4">
     <div class="navbar-start">
-        <a href="/dashboard" class="btn btn-ghost text-xl font-bold">
-            Joe Links
-        </a>
+        <a href="/dashboard" class="btn btn-ghost text-xl font-bold">Joe Links</a>
+    </div>
+    <div class="navbar-center hidden lg:flex">
+        <ul class="menu menu-horizontal px-1">
+            <li><a href="/dashboard">Dashboard</a></li>
+            <li><a href="/dashboard/tags">Tags</a></li>
+            {{if eq .User.Role "admin"}}<li><a href="/admin">Admin</a></li>{{end}}
+        </ul>
     </div>
     <div class="navbar-end gap-2">
         <!-- Governing: SPEC-0003 REQ "Theme Toggle Control" — sun when dark, moon when light -->
-        <button id="theme-toggle"
-                class="btn btn-ghost btn-circle"
+        <button id="theme-toggle" class="btn btn-ghost btn-circle"
                 hx-post="/dashboard/theme"
                 hx-vals='js:{theme: document.documentElement.getAttribute("data-theme") === "joe-dark" ? "joe-light" : "joe-dark"}'
                 hx-swap="none">
             <span id="theme-toggle-icon">{{if eq .Theme "joe-dark"}}☀️{{else}}🌙{{end}}</span>
         </button>
-        {{if .User}}
-        <span class="text-sm text-base-content/70">{{.User.DisplayName}}</span>
-        <form method="POST" action="/auth/logout">
-            <button class="btn btn-sm btn-ghost">Sign out</button>
-        </form>
-        {{else}}
-        <a href="/auth/login" class="btn btn-sm btn-primary">Sign in</a>
-        {{end}}
+        <div class="dropdown dropdown-end">
+            <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar placeholder">
+                <div class="bg-neutral text-neutral-content rounded-full w-8">
+                    <span class="text-xs">{{slice .User.DisplayName 0 1}}</span>
+                </div>
+            </div>
+            <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
+                <li><span class="text-sm font-medium">{{.User.DisplayName}}</span></li>
+                <li>
+                    <form method="POST" action="/auth/logout">
+                        <button type="submit">Sign out</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
     </div>
 </nav>
-
-{{if .Flash}}
-<div class="toast toast-top toast-end z-50">
-    <div class="alert alert-{{.Flash.Type}}">
-        <span>{{.Flash.Message}}</span>
+{{else}}
+<nav class="navbar bg-base-200 shadow-sm px-4">
+    <div class="navbar-start">
+        <a href="/" class="btn btn-ghost text-xl font-bold">Joe Links</a>
     </div>
-</div>
+    <div class="navbar-end gap-2">
+        <!-- Governing: SPEC-0003 REQ "Theme Toggle Control" — sun when dark, moon when light -->
+        <button id="theme-toggle" class="btn btn-ghost btn-circle"
+                hx-post="/dashboard/theme"
+                hx-vals='js:{theme: document.documentElement.getAttribute("data-theme") === "joe-dark" ? "joe-light" : "joe-dark"}'
+                hx-swap="none">
+            <span id="theme-toggle-icon">{{if eq .Theme "joe-dark"}}☀️{{else}}🌙{{end}}</span>
+        </button>
+        <a href="/auth/login" class="btn btn-sm btn-primary">Sign in</a>
+    </div>
+</nav>
 {{end}}
+
+<!-- Governing: SPEC-0004 REQ "Shared Base Layout" — toast area for HTMX OOB swaps -->
+<div id="toast-area" class="toast toast-top toast-end z-50"></div>
 
 <main class="container mx-auto px-4 py-8 max-w-4xl">
     {{block "content" .}}{{end}}
 </main>
+
+<!-- Governing: SPEC-0004 REQ "Shared Base Layout" — modal target for HTMX injection -->
+<div id="modal"></div>
 
 </body>
 </html>

--- a/web/templates/pages/404.html
+++ b/web/templates/pages/404.html
@@ -12,7 +12,7 @@
                 There's no short link for <span class="font-mono font-semibold">{{.Slug}}</span> yet.
             </p>
             {{if .User}}
-            <a href="/links/new?slug={{.Slug}}" class="btn btn-primary">Create this link</a>
+            <a href="/dashboard/links/new?slug={{.Slug}}" class="btn btn-primary">Create this link</a>
             {{else}}
             <a href="/auth/login" class="btn btn-primary">Sign in to create links</a>
             {{end}}

--- a/web/templates/pages/admin/dashboard.html
+++ b/web/templates/pages/admin/dashboard.html
@@ -1,0 +1,6 @@
+{{template "base" .}}
+{{define "title"}}Admin — Joe Links{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Admin Dashboard</h1>
+<p class="text-base-content/70">Admin views coming soon.</p>
+{{end}}

--- a/web/templates/pages/admin/links.html
+++ b/web/templates/pages/admin/links.html
@@ -1,0 +1,6 @@
+{{template "base" .}}
+{{define "title"}}All Links — Admin — Joe Links{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">All Links</h1>
+<p class="text-base-content/70">Admin links view coming soon.</p>
+{{end}}

--- a/web/templates/pages/admin/users.html
+++ b/web/templates/pages/admin/users.html
@@ -1,0 +1,6 @@
+{{template "base" .}}
+{{define "title"}}Users — Admin — Joe Links{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Users</h1>
+<p class="text-base-content/70">User management coming soon.</p>
+{{end}}

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -5,7 +5,7 @@
 {{define "content"}}
 <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">My Links</h1>
-    <a href="/links/new" class="btn btn-primary btn-sm">+ New link</a>
+    <a href="/dashboard/links/new" class="btn btn-primary btn-sm">+ New link</a>
 </div>
 
 {{if .Links}}
@@ -33,7 +33,7 @@
         <div>
             <h2 class="text-xl font-semibold mb-2">No links yet</h2>
             <p class="text-base-content/60 mb-4">Create your first short link to get started.</p>
-            <a href="/links/new" class="btn btn-primary">Create a link</a>
+            <a href="/dashboard/links/new" class="btn btn-primary">Create a link</a>
         </div>
     </div>
 </div>

--- a/web/templates/pages/landing.html
+++ b/web/templates/pages/landing.html
@@ -1,0 +1,13 @@
+{{template "base" .}}
+{{define "title"}}Joe Links — Short links for teams{{end}}
+{{define "content"}}
+<div class="hero min-h-[60vh]">
+    <div class="hero-content text-center">
+        <div class="max-w-md">
+            <h1 class="text-5xl font-bold">Joe Links</h1>
+            <p class="py-6">Self-hosted go links — short, memorable slugs that redirect to long URLs. Share <code>/jira</code> instead of that 200-character Jira URL.</p>
+            <a href="/auth/login" class="btn btn-primary">Sign in to get started</a>
+        </div>
+    </div>
+</div>
+{{end}}

--- a/web/templates/pages/links/detail.html
+++ b/web/templates/pages/links/detail.html
@@ -1,0 +1,16 @@
+{{template "base" .}}
+{{define "title"}}Link — Joe Links{{end}}
+{{define "content"}}
+<div class="card bg-base-200">
+    <div class="card-body">
+        {{if .Link}}
+        <h2 class="card-title">{{.Link.Slug}}</h2>
+        <p><a href="{{.Link.URL}}" class="link">{{.Link.URL}}</a></p>
+        {{if .Link.Description}}<p class="text-base-content/70">{{.Link.Description}}</p>{{end}}
+        <div class="card-actions justify-end">
+            <a href="/dashboard/links/{{.Link.ID}}/edit" class="btn btn-sm btn-primary">Edit</a>
+        </div>
+        {{end}}
+    </div>
+</div>
+{{end}}

--- a/web/templates/pages/links/edit.html
+++ b/web/templates/pages/links/edit.html
@@ -14,7 +14,7 @@
             </div>
             {{end}}
 
-            <form hx-put="/links/{{.Link.ID}}" hx-target="body" hx-push-url="/dashboard">
+            <form hx-put="/dashboard/links/{{.Link.ID}}" hx-target="body" hx-push-url="/dashboard">
                 <!-- Governing: SPEC-0001 REQ "Short Link Management" — slug is immutable after creation. -->
                 <div class="form-control mb-4">
                     <label class="label"><span class="label-text">Slug</span></label>

--- a/web/templates/pages/links/new.html
+++ b/web/templates/pages/links/new.html
@@ -14,7 +14,7 @@
             </div>
             {{end}}
 
-            <form method="POST" action="/links">
+            <form method="POST" action="/dashboard/links">
                 <div class="form-control mb-4">
                     <label class="label">
                         <span class="label-text">Slug <span class="text-error">*</span></span>

--- a/web/templates/pages/tags/detail.html
+++ b/web/templates/pages/tags/detail.html
@@ -1,0 +1,6 @@
+{{template "base" .}}
+{{define "title"}}Tag — Joe Links{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Tag</h1>
+<p class="text-base-content/70">Tag detail coming soon.</p>
+{{end}}

--- a/web/templates/pages/tags/index.html
+++ b/web/templates/pages/tags/index.html
@@ -1,0 +1,6 @@
+{{template "base" .}}
+{{define "title"}}Tags — Joe Links{{end}}
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Tags</h1>
+<p class="text-base-content/70">Tag browser coming soon.</p>
+{{end}}

--- a/web/templates/partials/link_row.html
+++ b/web/templates/partials/link_row.html
@@ -9,10 +9,10 @@
     <td class="text-sm text-base-content/60">{{.Description}}</td>
     <td class="text-sm text-base-content/60">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
     <td class="flex gap-1 justify-end">
-        <a href="/links/{{.ID}}/edit" class="btn btn-xs btn-ghost">Edit</a>
+        <a href="/dashboard/links/{{.ID}}/edit" class="btn btn-xs btn-ghost">Edit</a>
         <button
             class="btn btn-xs btn-error btn-ghost"
-            hx-delete="/links/{{.ID}}"
+            hx-delete="/dashboard/links/{{.ID}}"
             hx-target="#link-{{.ID}}"
             hx-swap="outerHTML"
             hx-confirm="Delete '{{.Slug}}'?"


### PR DESCRIPTION
## Summary

Implements the chi router with all middleware groups, complete route registration, and updates the shared base HTML layout with modal/toast targets and conditional admin nav link.

- **Router**: Full route set with correct `/dashboard/links/...` prefixes, admin group with `RequireRole("admin")` middleware, tag routes, co-owner routes, validate-slug endpoint, and landing page with `OptionalUser` middleware
- **Base layout**: Added `id="modal"` and `id="toast-area"` targets for HTMX injection/OOB swaps, Dashboard/Tags/Admin nav links in navbar, user avatar dropdown
- **Stub handlers**: Admin, tags, co-owners, link detail, and landing page handlers (full implementations in #18 and #19)

## Changes

| File | Change |
|------|--------|
| `internal/handler/router.go` | Full route set with middleware groups |
| `internal/handler/templates.go` | Added `User` field to `BasePage`, new template glob paths |
| `internal/auth/middleware.go` | Added `OptionalUser` middleware |
| `web/templates/base.html` | Navbar with nav links, conditional admin, modal/toast targets |
| `internal/handler/landing.go` | Landing page with auth redirect |
| `internal/handler/admin.go` | Admin handler stubs |
| `internal/handler/tags.go` | Tag handler stubs |
| `internal/handler/coowners.go` | Co-owner, link detail, and validate-slug handlers |
| `cmd/joe-links/serve.go` | Pass `TagStore` to router deps |
| `web/templates/pages/*` | Stub templates for admin, tags, link detail, landing; path fixes |

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Verify `/dashboard` routes take precedence over slug resolver
- [ ] Verify `/admin` routes require admin role (403 for non-admin)
- [ ] Verify unauthenticated GET `/` shows landing page
- [ ] Verify authenticated GET `/` redirects to `/dashboard`
- [ ] Verify navbar shows Admin link only for admin role

Closes #16
Part of #4 (epic)
Governing: SPEC-0004 REQ "Route Registration and Priority", "Shared Base Layout"

🤖 Generated with [Claude Code](https://claude.com/claude-code)