### PR TITLE
Landing Page, Dashboard & Slug Resolver

### DIFF
--- a/internal/handler/dashboard.go
+++ b/internal/handler/dashboard.go
@@ -1,5 +1,6 @@
 // Governing: SPEC-0001 REQ "Short Link Management", REQ "HTMX Hypermedia Interactions", ADR-0001
 // Governing: SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
+// Governing: SPEC-0004 REQ "User Dashboard"
 package handler
 
 import (
@@ -14,39 +15,78 @@ type DashboardPage struct {
 	BasePage
 	User  *store.User
 	Links []*store.Link
+	Tags  []*store.Tag
+	Query string // current search query
+	Tag   string // current tag filter slug
 	Flash *Flash
 }
 
 // DashboardHandler serves the authenticated link management dashboard.
 type DashboardHandler struct {
 	links *store.LinkStore
+	tags  *store.TagStore
 }
 
 // NewDashboardHandler creates a new DashboardHandler.
-func NewDashboardHandler(ls *store.LinkStore) *DashboardHandler {
-	return &DashboardHandler{links: ls}
+// Governing: SPEC-0004 REQ "User Dashboard"
+func NewDashboardHandler(ls *store.LinkStore, ts *store.TagStore) *DashboardHandler {
+	return &DashboardHandler{links: ls, tags: ts}
 }
 
 // Show renders the dashboard with the user's links (or all links for admins).
+// Supports ?q= for search and ?tag= for tag filtering via HTMX.
+// Governing: SPEC-0004 REQ "User Dashboard"
 // Governing: SPEC-0001 REQ "HTMX Hypermedia Interactions"
 func (h *DashboardHandler) Show(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
+	query := r.URL.Query().Get("q")
+	tagSlug := r.URL.Query().Get("tag")
 
 	var links []*store.Link
 	var err error
-	if user.IsAdmin() {
-		links, err = h.links.ListAll(r.Context())
-	} else {
-		links, err = h.links.ListByOwner(r.Context(), user.ID)
+
+	switch {
+	case tagSlug != "":
+		// Tag filter takes precedence
+		if user.IsAdmin() {
+			links, err = h.links.ListByTag(r.Context(), tagSlug)
+		} else {
+			links, err = h.links.ListByOwnerAndTag(r.Context(), user.ID, tagSlug)
+		}
+	case query != "":
+		// Search filter
+		if user.IsAdmin() {
+			links, err = h.links.SearchAll(r.Context(), query)
+		} else {
+			links, err = h.links.SearchByOwner(r.Context(), user.ID, query)
+		}
+	default:
+		// No filters
+		if user.IsAdmin() {
+			links, err = h.links.ListAll(r.Context())
+		} else {
+			links, err = h.links.ListByOwner(r.Context(), user.ID)
+		}
 	}
 	if err != nil {
 		http.Error(w, "could not load links", http.StatusInternalServerError)
 		return
 	}
 
-	data := DashboardPage{BasePage: BasePage{Theme: themeFromRequest(r), User: user}, User: user, Links: links}
+	// Load all tags for the tag filter chips
+	allTags, _ := h.tags.ListAll(r.Context())
+
+	data := DashboardPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		User:     user,
+		Links:    links,
+		Tags:     allTags,
+		Query:    query,
+		Tag:      tagSlug,
+	}
+
 	if isHTMX(r) {
-		renderFragment(w, "content", data)
+		renderFragment(w, "link_list", data)
 		return
 	}
 	render(w, "dashboard.html", data)

--- a/internal/handler/resolve.go
+++ b/internal/handler/resolve.go
@@ -1,5 +1,6 @@
 // Governing: SPEC-0001 REQ "Short Link Resolution", REQ "HTMX Hypermedia Interactions", ADR-0001
 // Governing: SPEC-0003 REQ "Theme Persistence via Cookie", ADR-0006
+// Governing: SPEC-0004 REQ "Slug Resolver and 404 Page"
 package handler
 
 import (

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -63,7 +63,7 @@ func NewRouter(deps Deps) http.Handler {
 
 	// Authenticated routes
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — dashboard, link, and tag routes
-	dashboard := NewDashboardHandler(deps.LinkStore)
+	dashboard := NewDashboardHandler(deps.LinkStore, deps.TagStore)
 	links := NewLinksHandler(deps.LinkStore, deps.OwnershipStore)
 	tags := NewTagsHandler(deps.TagStore)
 

--- a/web/templates/pages/404.html
+++ b/web/templates/pages/404.html
@@ -3,6 +3,7 @@
 {{define "title"}}Not Found — Joe Links{{end}}
 
 {{define "content"}}
+<!-- Governing: SPEC-0004 REQ "Slug Resolver and 404 Page" -->
 <div class="hero py-24">
     <div class="hero-content text-center">
         <div>
@@ -14,7 +15,7 @@
             {{if .User}}
             <a href="/dashboard/links/new?slug={{.Slug}}" class="btn btn-primary">Create this link</a>
             {{else}}
-            <a href="/auth/login" class="btn btn-primary">Sign in to create links</a>
+            <a href="/auth/login?redirect=/dashboard/links/new%3Fslug%3D{{.Slug}}" class="btn btn-primary">Sign in to create this link</a>
             {{end}}
         </div>
     </div>

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -8,34 +8,41 @@
     <a href="/dashboard/links/new" class="btn btn-primary btn-sm">+ New link</a>
 </div>
 
-{{if .Links}}
-<div class="overflow-x-auto">
-    <table class="table table-zebra w-full">
-        <thead>
-            <tr>
-                <th>Slug</th>
-                <th>URL</th>
-                <th>Description</th>
-                <th>Created</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody id="links-table">
-            {{range .Links}}
-            {{template "link_row" .}}
-            {{end}}
-        </tbody>
-    </table>
+<!-- Governing: SPEC-0004 REQ "User Dashboard" — search input with HTMX debounce -->
+<div class="flex flex-col sm:flex-row gap-3 mb-6">
+    <input
+        type="search"
+        name="q"
+        class="input input-bordered flex-1"
+        placeholder="Search links by slug, URL, or description..."
+        value="{{.Query}}"
+        hx-get="/dashboard"
+        hx-trigger="input changed delay:400ms, search"
+        hx-target="#link-list"
+        hx-include="this"
+        hx-push-url="false"
+    >
 </div>
-{{else}}
-<div class="hero py-16">
-    <div class="hero-content text-center">
-        <div>
-            <h2 class="text-xl font-semibold mb-2">No links yet</h2>
-            <p class="text-base-content/60 mb-4">Create your first short link to get started.</p>
-            <a href="/dashboard/links/new" class="btn btn-primary">Create a link</a>
-        </div>
-    </div>
+
+<!-- Governing: SPEC-0004 REQ "User Dashboard" — tag filter chips -->
+{{if .Tags}}
+<div class="flex flex-wrap gap-2 mb-6">
+    <a href="/dashboard"
+       class="badge badge-outline {{if not .Tag}}badge-primary{{end}} cursor-pointer"
+       hx-get="/dashboard"
+       hx-target="#link-list"
+       hx-push-url="false">All</a>
+    {{range .Tags}}
+    <a href="/dashboard?tag={{.Slug}}"
+       class="badge badge-outline {{if eq $.Tag .Slug}}badge-primary{{end}} cursor-pointer"
+       hx-get="/dashboard?tag={{.Slug}}"
+       hx-target="#link-list"
+       hx-push-url="false">{{.Name}}</a>
+    {{end}}
 </div>
 {{end}}
+
+<div id="link-list">
+{{template "link_list" .}}
+</div>
 {{end}}

--- a/web/templates/pages/landing.html
+++ b/web/templates/pages/landing.html
@@ -1,12 +1,18 @@
 {{template "base" .}}
 {{define "title"}}Joe Links — Short links for teams{{end}}
 {{define "content"}}
+<!-- Governing: SPEC-0004 REQ "Landing Page" — hero + sign-in CTA for unauthenticated users -->
 <div class="hero min-h-[60vh]">
     <div class="hero-content text-center">
-        <div class="max-w-md">
+        <div class="max-w-lg">
             <h1 class="text-5xl font-bold">Joe Links</h1>
-            <p class="py-6">Self-hosted go links — short, memorable slugs that redirect to long URLs. Share <code>/jira</code> instead of that 200-character Jira URL.</p>
-            <a href="/auth/login" class="btn btn-primary">Sign in to get started</a>
+            <p class="py-6 text-lg text-base-content/80">
+                Self-hosted go links — short, memorable slugs that redirect to long URLs.
+                Share <code class="bg-base-200 px-2 py-1 rounded font-mono">/jira</code> instead of that 200-character Jira URL.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-3 justify-center">
+                <a href="/auth/login" class="btn btn-primary btn-lg">Sign in to get started</a>
+            </div>
         </div>
     </div>
 </div>

--- a/web/templates/partials/link_list.html
+++ b/web/templates/partials/link_list.html
@@ -1,0 +1,44 @@
+{{define "link_list"}}
+{{if .Links}}
+<div class="overflow-x-auto">
+    <table class="table table-zebra w-full">
+        <thead>
+            <tr>
+                <th>Slug</th>
+                <th>URL</th>
+                <th>Description</th>
+                <th>Created</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody id="links-table">
+            {{range .Links}}
+            {{template "link_row" .}}
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+{{if or $.Query $.Tag}}
+<div class="hero py-16">
+    <div class="hero-content text-center">
+        <div>
+            <h2 class="text-xl font-semibold mb-2">No matching links</h2>
+            <p class="text-base-content/60 mb-4">Try a different search or clear filters.</p>
+            <a href="/dashboard" class="btn btn-ghost">Clear filters</a>
+        </div>
+    </div>
+</div>
+{{else}}
+<div class="hero py-16">
+    <div class="hero-content text-center">
+        <div>
+            <h2 class="text-xl font-semibold mb-2">No links yet</h2>
+            <p class="text-base-content/60 mb-4">Create your first short link to get started.</p>
+            <a href="/dashboard/links/new" class="btn btn-primary">Create a link</a>
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary

Implements the landing page for unauthenticated users, enhances the dashboard with HTMX-debounced search and tag filtering, and improves the slug resolver 404 page with proper login redirects.

- **Landing page**: Hero section with sign-in CTA; authenticated users are redirected to `/dashboard` via `OptionalUser` middleware
- **Dashboard**: Search input with `hx-trigger="input changed delay:400ms"` filtering by slug/URL/description; tag filter chips with active state; distinct empty states for "no links" vs "no matching links"
- **Slug resolver 404**: Friendly page showing the missing slug; authenticated users get "Create this link" CTA; unauthenticated users get "Sign in to create" with redirect param preserving the slug

## Changes

| File | Change |
|------|--------|
| `internal/handler/dashboard.go` | Accepts `?q=` and `?tag=` params; returns `link_list` fragment for HTMX; passes tags for filter chips |
| `internal/handler/router.go` | Pass `TagStore` to `NewDashboardHandler` |
| `internal/store/link_store.go` | `SearchByOwner`, `SearchAll`, `ListByOwnerAndTag` query methods |
| `web/templates/pages/dashboard.html` | Search input, tag chips, `#link-list` swap target |
| `web/templates/partials/link_list.html` | New partial for HTMX fragment responses |
| `web/templates/pages/landing.html` | Enhanced hero with code sample and larger CTA |
| `web/templates/pages/404.html` | Login redirect with slug pre-fill for unauthenticated users |
| `internal/handler/resolve.go` | Added SPEC-0004 governing comment |

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Verify `GET /` renders landing page for unauthenticated users
- [ ] Verify `GET /` redirects to `/dashboard` for authenticated users
- [ ] Verify dashboard search filters links with 400ms debounce
- [ ] Verify dashboard tag chips filter link list
- [ ] Verify empty state shows "Create a link" CTA when no links exist
- [ ] Verify empty state shows "Clear filters" when search/tag has no results
- [ ] Verify `GET /{slug}` returns 302 for known slugs
- [ ] Verify `GET /{slug}` returns 404 with slug name for unknown slugs
- [ ] Verify unauthenticated 404 "Sign in" link includes redirect param with slug

Closes #17
Part of #4 (epic)
Governing: SPEC-0004 REQ "Landing Page", "User Dashboard", "Slug Resolver and 404 Page"

🤖 Generated with [Claude Code](https://claude.com/claude-code)