### PR TITLE
Token Management — API & Web UI (SPEC-0006)

### DIFF
--- a/cmd/joe-links/serve.go
+++ b/cmd/joe-links/serve.go
@@ -46,11 +46,10 @@ func newServeCmd() *cobra.Command {
 			ownershipStore := store.NewOwnershipStore(database)
 			tagStore := store.NewTagStore(database)
 			linkStore := store.NewLinkStore(database, ownershipStore, tagStore)
+			tokenStore := auth.NewSQLTokenStore(database)
 
 			authHandlers := auth.NewHandlers(oidcProvider, sessionManager, userStore, cfg.AdminEmail)
 			authMiddleware := auth.NewMiddleware(sessionManager, userStore)
-
-			tokenStore := auth.NewSQLTokenStore(database)
 
 			router := handler.NewRouter(handler.Deps{
 				SessionManager: sessionManager,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -33,11 +33,9 @@ func NewAPIRouter(deps Deps) http.Handler {
 	// Governing: SPEC-0006 REQ "No Web UI Session on API Routes"
 	r.Use(deps.BearerMiddleware.Authenticate)
 
-	// NOTE: Route handlers will be registered by subsequent stories.
-	// Placeholder to allow initial build:
-	r.Get("/ping", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"status":"ok"}`))
-	})
+	// Token management routes.
+	// Governing: SPEC-0006 REQ "Token Management API"
+	registerTokenRoutes(r, deps.TokenStore)
 
 	return r
 }

--- a/internal/api/tokens.go
+++ b/internal/api/tokens.go
@@ -1,0 +1,135 @@
+// Governing: SPEC-0006 REQ "Token Management API", ADR-0009
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// tokensAPIHandler provides REST handlers for API token management.
+// Governing: SPEC-0006 REQ "Token Management API" — Bearer token auth only.
+type tokensAPIHandler struct {
+	tokens auth.TokenStore
+}
+
+// registerTokenRoutes registers token management routes on r.
+// Governing: SPEC-0006 REQ "Token Management API"
+func registerTokenRoutes(r chi.Router, tokens auth.TokenStore) {
+	h := &tokensAPIHandler{tokens: tokens}
+	r.Get("/tokens", h.List)
+	r.Post("/tokens", h.Create)
+	r.Delete("/tokens/{id}", h.Revoke)
+}
+
+// List returns the caller's tokens without sensitive fields.
+// GET /api/v1/tokens
+// Governing: SPEC-0006 REQ "Token Management API" — response MUST NOT include token_hash.
+func (h *tokensAPIHandler) List(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
+		return
+	}
+
+	records, err := h.tokens.ListByUser(r.Context(), user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "internal_error")
+		return
+	}
+
+	resp := &TokenListResponse{Tokens: make([]*TokenResponse, 0, len(records))}
+	for _, rec := range records {
+		item := &TokenResponse{
+			ID:        rec.ID,
+			Name:      rec.Name,
+			CreatedAt: rec.CreatedAt,
+		}
+		if rec.LastUsedAt.Valid {
+			t := rec.LastUsedAt.Time
+			item.LastUsedAt = &t
+		}
+		if rec.ExpiresAt.Valid {
+			t := rec.ExpiresAt.Time
+			item.ExpiresAt = &t
+		}
+		resp.Tokens = append(resp.Tokens, item)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Create generates a new token and returns the plaintext once.
+// POST /api/v1/tokens
+// Governing: SPEC-0006 REQ "Token Management API" — plaintext MUST NOT appear in any subsequent call.
+func (h *tokensAPIHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
+		return
+	}
+
+	var req CreateTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body", "bad_request")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required", "bad_request")
+		return
+	}
+
+	plaintext, hash, err := auth.GenerateToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "token generation failed", "internal_error")
+		return
+	}
+
+	rec, err := h.tokens.Create(r.Context(), user.ID, req.Name, hash, req.ExpiresAt)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "token creation failed", "internal_error")
+		return
+	}
+
+	item := &TokenResponse{
+		ID:        rec.ID,
+		Name:      rec.Name,
+		CreatedAt: rec.CreatedAt,
+	}
+	if rec.ExpiresAt.Valid {
+		t := rec.ExpiresAt.Time
+		item.ExpiresAt = &t
+	}
+
+	writeJSON(w, http.StatusCreated, TokenCreatedResponse{
+		TokenResponse: *item,
+		Token:         plaintext,
+	})
+}
+
+// Revoke soft-deletes a token owned by the current user.
+// DELETE /api/v1/tokens/{id}
+// Governing: SPEC-0006 REQ "Token Management API" — returns 404 for other users' tokens.
+func (h *tokensAPIHandler) Revoke(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "unauthorized")
+		return
+	}
+
+	tokenID := chi.URLParam(r, "id")
+	err := h.tokens.Revoke(r.Context(), tokenID, user.ID)
+	if err == store.ErrNotFound {
+		writeError(w, http.StatusNotFound, "not found", "not_found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "revoke failed", "internal_error")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -70,6 +70,7 @@ func NewRouter(deps Deps) http.Handler {
 	dashboard := NewDashboardHandler(deps.LinkStore, deps.TagStore)
 	links := NewLinksHandler(deps.LinkStore, deps.OwnershipStore, deps.UserStore)
 	tags := NewTagsHandler(deps.TagStore, deps.LinkStore)
+	tokensWeb := NewTokensHandler(deps.TokenStore)
 
 	r.Group(func(r chi.Router) {
 		r.Use(deps.AuthMiddleware.RequireAuth)
@@ -90,6 +91,11 @@ func NewRouter(deps Deps) http.Handler {
 		r.Get("/dashboard/tags", tags.Index)
 		r.Get("/dashboard/tags/suggest", tags.Suggest)
 		r.Get("/dashboard/tags/{slug}", tags.Detail)
+
+		// Governing: SPEC-0006 REQ "Token Management Web UI"
+		r.Get("/dashboard/settings/tokens", tokensWeb.Index)
+		r.Post("/dashboard/settings/tokens", tokensWeb.Create)
+		r.Delete("/dashboard/settings/tokens/{id}", tokensWeb.Revoke)
 	})
 
 	// Admin routes (require admin role)

--- a/internal/handler/templates.go
+++ b/internal/handler/templates.go
@@ -43,6 +43,7 @@ func init() {
 		"templates/pages/links/*.html",
 		"templates/pages/admin/*.html",
 		"templates/pages/tags/*.html",
+		"templates/pages/settings/*.html",
 	)
 	if err != nil {
 		panic("failed to parse templates: " + err.Error())

--- a/internal/handler/tokens.go
+++ b/internal/handler/tokens.go
@@ -1,0 +1,161 @@
+// Governing: SPEC-0006 REQ "Token Management Web UI", ADR-0009
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// TokensPage is the template data for the token management settings page.
+type TokensPage struct {
+	BasePage
+	User     *store.User
+	Tokens   []*auth.TokenRecord
+	NewToken string // plaintext shown once after creation; empty otherwise
+	Flash    *Flash
+	Error    string
+}
+
+// TokensHandler provides web UI handlers for token management.
+type TokensHandler struct {
+	tokens auth.TokenStore
+}
+
+// NewTokensHandler creates a new TokensHandler.
+func NewTokensHandler(ts auth.TokenStore) *TokensHandler {
+	return &TokensHandler{tokens: ts}
+}
+
+// Index renders the token management page with the user's active tokens.
+// GET /dashboard/settings/tokens
+// Governing: SPEC-0006 REQ "Token Management Web UI"
+func (h *TokensHandler) Index(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	records, err := h.tokens.ListByUser(r.Context(), user.ID)
+	if err != nil {
+		http.Error(w, "could not load tokens", http.StatusInternalServerError)
+		return
+	}
+
+	data := TokensPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		User:     user,
+		Tokens:   records,
+	}
+
+	if isHTMX(r) {
+		renderFragment(w, "token_list", data)
+		return
+	}
+	render(w, "tokens.html", data)
+}
+
+// Create processes the token creation form and shows the plaintext once.
+// POST /dashboard/settings/tokens
+// Governing: SPEC-0006 REQ "Token Management Web UI" — one-time reveal of plaintext.
+func (h *TokensHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	name := r.FormValue("name")
+	if name == "" {
+		h.renderWithError(w, r, user, "Token name is required.")
+		return
+	}
+
+	var expiresAt *time.Time
+	if exp := r.FormValue("expires_in"); exp != "" {
+		d, err := time.ParseDuration(exp)
+		if err != nil {
+			h.renderWithError(w, r, user, "Invalid expiry duration.")
+			return
+		}
+		t := time.Now().Add(d)
+		expiresAt = &t
+	}
+
+	plaintext, hash, err := auth.GenerateToken()
+	if err != nil {
+		h.renderWithError(w, r, user, "Failed to generate token.")
+		return
+	}
+
+	_, err = h.tokens.Create(r.Context(), user.ID, name, hash, expiresAt)
+	if err != nil {
+		h.renderWithError(w, r, user, "Failed to create token.")
+		return
+	}
+
+	records, _ := h.tokens.ListByUser(r.Context(), user.ID)
+
+	data := TokensPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		User:     user,
+		Tokens:   records,
+		NewToken: plaintext,
+		Flash:    &Flash{Type: "success", Message: "Token created. Copy it now — it will not be shown again."},
+	}
+
+	if isHTMX(r) {
+		renderFragment(w, "token_list", data)
+		return
+	}
+	render(w, "tokens.html", data)
+}
+
+// Revoke soft-deletes a token owned by the current user.
+// DELETE /dashboard/settings/tokens/{id}
+// Governing: SPEC-0006 REQ "Token Management Web UI" — revocation with confirmation.
+func (h *TokensHandler) Revoke(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	tokenID := chi.URLParam(r, "id")
+
+	err := h.tokens.Revoke(r.Context(), tokenID, user.ID)
+	if err == store.ErrNotFound {
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		http.Error(w, "revoke failed", http.StatusInternalServerError)
+		return
+	}
+
+	records, _ := h.tokens.ListByUser(r.Context(), user.ID)
+
+	data := TokensPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		User:     user,
+		Tokens:   records,
+		Flash:    &Flash{Type: "success", Message: "Token revoked."},
+	}
+
+	if isHTMX(r) {
+		renderFragment(w, "token_list", data)
+		return
+	}
+	render(w, "tokens.html", data)
+}
+
+func (h *TokensHandler) renderWithError(w http.ResponseWriter, r *http.Request, user *store.User, errMsg string) {
+	records, _ := h.tokens.ListByUser(r.Context(), user.ID)
+	data := TokensPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		User:     user,
+		Tokens:   records,
+		Error:    errMsg,
+	}
+	if isHTMX(r) {
+		renderFragment(w, "token_list", data)
+		return
+	}
+	render(w, "tokens.html", data)
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -41,6 +41,7 @@
             </div>
             <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
                 <li><span class="text-sm font-medium">{{.User.DisplayName}}</span></li>
+                <li><a href="/dashboard/settings/tokens">API Tokens</a></li>
                 <li>
                     <form method="POST" action="/auth/logout">
                         <button type="submit">Sign out</button>

--- a/web/templates/pages/settings/tokens.html
+++ b/web/templates/pages/settings/tokens.html
@@ -1,0 +1,14 @@
+{{template "base" .}}
+
+{{define "title"}}API Tokens — Joe Links{{end}}
+
+{{define "content"}}
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">API Tokens</h1>
+    <a href="/dashboard" class="btn btn-ghost btn-sm">Back to Dashboard</a>
+</div>
+
+<div id="token-content">
+{{template "token_list" .}}
+</div>
+{{end}}

--- a/web/templates/partials/token_list.html
+++ b/web/templates/partials/token_list.html
@@ -1,0 +1,104 @@
+{{define "token_list"}}
+{{if .Flash}}
+<div class="alert alert-{{.Flash.Type}} mb-4">
+    <span>{{.Flash.Message}}</span>
+</div>
+{{end}}
+
+{{if .Error}}
+<div class="alert alert-error mb-4">
+    <span>{{.Error}}</span>
+</div>
+{{end}}
+
+<!-- Governing: SPEC-0006 REQ "Token Management Web UI" — one-time token reveal -->
+{{if .NewToken}}
+<div class="alert alert-warning mb-6 shadow-lg">
+    <div>
+        <h3 class="font-bold">Your new API token</h3>
+        <p class="text-sm">Copy this token now. You will not be able to see it again.</p>
+        <code class="block mt-2 p-3 bg-base-300 rounded text-sm break-all select-all font-mono">{{.NewToken}}</code>
+    </div>
+</div>
+{{end}}
+
+<!-- New Token form -->
+<div class="card bg-base-200 mb-6">
+    <div class="card-body">
+        <h2 class="card-title text-lg">Create a new token</h2>
+        <form hx-post="/dashboard/settings/tokens"
+              hx-target="#token-content"
+              hx-swap="innerHTML"
+              class="flex flex-col sm:flex-row gap-3 items-end">
+            <div class="form-control flex-1">
+                <label class="label"><span class="label-text">Token name</span></label>
+                <input type="text" name="name" class="input input-bordered w-full"
+                       placeholder="e.g. CI/CD pipeline" required>
+            </div>
+            <div class="form-control w-full sm:w-48">
+                <label class="label"><span class="label-text">Expires in</span></label>
+                <select name="expires_in" class="select select-bordered w-full">
+                    <option value="">Never</option>
+                    <option value="720h">30 days</option>
+                    <option value="2160h">90 days</option>
+                    <option value="8760h">1 year</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Create token</button>
+        </form>
+    </div>
+</div>
+
+<!-- Token list -->
+{{if .Tokens}}
+<div class="overflow-x-auto">
+    <table class="table table-zebra w-full">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Created</th>
+                <th>Last used</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Tokens}}
+            <tr>
+                <td class="font-medium">{{.Name}}</td>
+                <td>{{.CreatedAt.Format "Jan 2, 2006"}}</td>
+                <td>{{if .LastUsedAt.Valid}}{{.LastUsedAt.Time.Format "Jan 2, 2006"}}{{else}}<span class="text-base-content/40">Never</span>{{end}}</td>
+                <td>{{if .ExpiresAt.Valid}}{{.ExpiresAt.Time.Format "Jan 2, 2006"}}{{else}}<span class="text-base-content/40">Never</span>{{end}}</td>
+                <td>
+                    {{if .RevokedAt.Valid}}
+                    <span class="badge badge-error badge-sm">Revoked</span>
+                    {{else}}
+                    <span class="badge badge-success badge-sm">Active</span>
+                    {{end}}
+                </td>
+                <td>
+                    {{if not .RevokedAt.Valid}}
+                    <button class="btn btn-ghost btn-xs text-error"
+                            hx-delete="/dashboard/settings/tokens/{{.ID}}"
+                            hx-target="#token-content"
+                            hx-swap="innerHTML"
+                            hx-confirm="Revoke this token? Any applications using it will stop working.">Revoke</button>
+                    {{end}}
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<div class="hero py-16">
+    <div class="hero-content text-center">
+        <div>
+            <h2 class="text-xl font-semibold mb-2">No API tokens</h2>
+            <p class="text-base-content/60">Create a token above to start using the API.</p>
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
Closes #44
Part of #38 (epic)
Governing: SPEC-0006 REQ "Token Management API", REQ "Token Management Web UI", ADR-0009

## Summary
- Add REST API endpoints for token lifecycle: `GET /api/v1/tokens` (list, no sensitive fields), `POST /api/v1/tokens` (create, plaintext returned once), `DELETE /api/v1/tokens/{id}` (revoke, own tokens only, 404 for others)
- Add HTMX web UI at `/dashboard/settings/tokens`: token list, creation form with name + expiry, one-time plaintext reveal with copy warning, revocation with `hx-confirm` dialog
- Wire `TokenStore` and `BearerTokenMiddleware` into router Deps and `serve.go`
- Add "API Tokens" link to user dropdown in base layout navbar

## Test plan
- [ ] `go build ./...` passes
- [ ] `GET /api/v1/tokens` with valid Bearer token returns token list without `token_hash`
- [ ] `POST /api/v1/tokens` returns `{"token": "jl_...", "id": "...", "name": "..."}` with 201
- [ ] `DELETE /api/v1/tokens/{id}` for own token returns 204; for other user's token returns 404
- [ ] `GET /dashboard/settings/tokens` (session auth) renders token list and creation form
- [ ] Creating a token via web UI shows one-time plaintext alert; refresh hides it
- [ ] Revoking a token via web UI shows confirmation dialog, then updates list
- [ ] API routes reject requests without Bearer token (no session fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)