### PR TITLE
Tag Browser & Admin Views

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -4,37 +4,97 @@ package handler
 import (
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
 )
 
 // AdminHandler serves admin views.
-type AdminHandler struct{}
+type AdminHandler struct {
+	links *store.LinkStore
+	users *store.UserStore
+}
 
 // NewAdminHandler creates a new AdminHandler.
-func NewAdminHandler() *AdminHandler { return &AdminHandler{} }
+func NewAdminHandler(ls *store.LinkStore, us *store.UserStore) *AdminHandler {
+	return &AdminHandler{links: ls, users: us}
+}
 
-// Dashboard renders the admin overview.
+// AdminDashboardPage is the template data for the admin overview.
+type AdminDashboardPage struct {
+	BasePage
+	UserCount int
+	LinkCount int
+}
+
+// AdminUsersPage is the template data for the user management list.
+type AdminUsersPage struct {
+	BasePage
+	Users []*store.User
+}
+
+// AdminLinksPage is the template data for the admin link list.
+type AdminLinksPage struct {
+	BasePage
+	Links []*store.Link
+}
+
+// Dashboard renders the admin overview with summary stats.
+// Governing: SPEC-0004 REQ "Admin Dashboard"
 func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	data := BasePage{Theme: themeFromRequest(r), User: user}
+	allUsers, _ := h.users.ListAll(r.Context())
+	allLinks, _ := h.links.ListAll(r.Context())
+	data := AdminDashboardPage{
+		BasePage:  BasePage{Theme: themeFromRequest(r), User: user},
+		UserCount: len(allUsers),
+		LinkCount: len(allLinks),
+	}
 	render(w, "admin/dashboard.html", data)
 }
 
 // Users renders the user management list.
+// Governing: SPEC-0004 REQ "Admin Dashboard"
 func (h *AdminHandler) Users(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	data := BasePage{Theme: themeFromRequest(r), User: user}
+	allUsers, _ := h.users.ListAll(r.Context())
+	data := AdminUsersPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		Users:    allUsers,
+	}
 	render(w, "admin/users.html", data)
 }
 
-// UpdateRole handles PUT /admin/users/{id}/role.
+// UpdateRole handles PUT /admin/users/{id}/role — updates role and returns updated row fragment.
+// Governing: SPEC-0004 REQ "Admin Dashboard" — inline role toggle via HTMX
 func (h *AdminHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "not implemented", http.StatusNotImplemented)
+	id := chi.URLParam(r, "id")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	role := r.FormValue("role")
+	if role != "admin" && role != "user" {
+		http.Error(w, "invalid role", http.StatusBadRequest)
+		return
+	}
+	target, err := h.users.UpdateRole(r.Context(), id, role)
+	if err != nil {
+		http.Error(w, "update failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	renderFragment(w, "user_row", target)
 }
 
-// Links renders the admin link list.
+// Links renders the admin link list (all links across all users).
+// Governing: SPEC-0004 REQ "Admin Dashboard"
 func (h *AdminHandler) Links(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	data := BasePage{Theme: themeFromRequest(r), User: user}
+	allLinks, _ := h.links.ListAll(r.Context())
+	data := AdminLinksPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		Links:    allLinks,
+	}
 	render(w, "admin/links.html", data)
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -66,7 +66,7 @@ func NewRouter(deps Deps) http.Handler {
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — dashboard, link, and tag routes
 	dashboard := NewDashboardHandler(deps.LinkStore, deps.TagStore)
 	links := NewLinksHandler(deps.LinkStore, deps.OwnershipStore, deps.UserStore)
-	tags := NewTagsHandler(deps.TagStore)
+	tags := NewTagsHandler(deps.TagStore, deps.LinkStore)
 
 	r.Group(func(r chi.Router) {
 		r.Use(deps.AuthMiddleware.RequireAuth)
@@ -91,7 +91,7 @@ func NewRouter(deps Deps) http.Handler {
 
 	// Admin routes (require admin role)
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — admin group with RequireAdmin
-	admin := NewAdminHandler()
+	admin := NewAdminHandler(deps.LinkStore, deps.UserStore)
 	r.Group(func(r chi.Router) {
 		r.Use(deps.AuthMiddleware.RequireAuth)
 		r.Use(deps.AuthMiddleware.RequireRole("admin"))

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -89,3 +89,25 @@ func (s *UserStore) GetByID(ctx context.Context, id string) (*User, error) {
 	}
 	return &u, nil
 }
+
+// ListAll returns all users ordered by display name.
+// Governing: SPEC-0004 REQ "Admin Dashboard"
+func (s *UserStore) ListAll(ctx context.Context) ([]*User, error) {
+	var users []*User
+	err := s.db.SelectContext(ctx, &users, `SELECT * FROM users ORDER BY display_name ASC`)
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// UpdateRole sets the role for the given user and returns the updated record.
+// Governing: SPEC-0004 REQ "Admin Dashboard" — inline role toggle
+func (s *UserStore) UpdateRole(ctx context.Context, id, role string) (*User, error) {
+	_, err := s.db.ExecContext(ctx, `UPDATE users SET role = ?, updated_at = ? WHERE id = ?`,
+		role, time.Now().UTC(), id)
+	if err != nil {
+		return nil, err
+	}
+	return s.GetByID(ctx, id)
+}

--- a/web/templates/pages/admin/dashboard.html
+++ b/web/templates/pages/admin/dashboard.html
@@ -1,6 +1,25 @@
 {{template "base" .}}
+
 {{define "title"}}Admin — Joe Links{{end}}
+
 {{define "content"}}
+<!-- Governing: SPEC-0004 REQ "Admin Dashboard" -->
 <h1 class="text-2xl font-bold mb-6">Admin Dashboard</h1>
-<p class="text-base-content/70">Admin views coming soon.</p>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-md">
+    <div class="stat bg-base-200 rounded-box shadow">
+        <div class="stat-title">Total Users</div>
+        <div class="stat-value text-primary">{{.UserCount}}</div>
+        <div class="stat-actions">
+            <a href="/admin/users" class="btn btn-sm btn-ghost">Manage →</a>
+        </div>
+    </div>
+    <div class="stat bg-base-200 rounded-box shadow">
+        <div class="stat-title">Total Links</div>
+        <div class="stat-value text-primary">{{.LinkCount}}</div>
+        <div class="stat-actions">
+            <a href="/admin/links" class="btn btn-sm btn-ghost">View →</a>
+        </div>
+    </div>
+</div>
 {{end}}

--- a/web/templates/pages/admin/links.html
+++ b/web/templates/pages/admin/links.html
@@ -1,6 +1,45 @@
 {{template "base" .}}
+
 {{define "title"}}All Links — Admin — Joe Links{{end}}
+
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">All Links</h1>
-<p class="text-base-content/70">Admin links view coming soon.</p>
+<!-- Governing: SPEC-0004 REQ "Admin Dashboard" -->
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">All Links</h1>
+    <div class="flex items-center gap-3">
+        <span class="text-base-content/60 text-sm">{{len .Links}} total</span>
+        <a href="/admin" class="btn btn-ghost btn-sm">← Admin</a>
+    </div>
+</div>
+
+{{if .Links}}
+<div class="overflow-x-auto">
+    <table class="table table-sm">
+        <thead>
+            <tr>
+                <th>Slug</th>
+                <th>Destination</th>
+                <th>Description</th>
+                <th>Created</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Links}}
+            <tr>
+                <td>
+                    <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
+                </td>
+                <td class="max-w-xs truncate text-sm">
+                    <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
+                </td>
+                <td class="text-sm text-base-content/70">{{.Description}}</td>
+                <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<p class="text-base-content/60 py-8 text-center">No links yet.</p>
+{{end}}
 {{end}}

--- a/web/templates/pages/admin/users.html
+++ b/web/templates/pages/admin/users.html
@@ -1,6 +1,66 @@
 {{template "base" .}}
+
 {{define "title"}}Users — Admin — Joe Links{{end}}
+
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Users</h1>
-<p class="text-base-content/70">User management coming soon.</p>
+<!-- Governing: SPEC-0004 REQ "Admin Dashboard" -->
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">Users</h1>
+    <a href="/admin" class="btn btn-ghost btn-sm">← Admin</a>
+</div>
+
+{{if .Users}}
+<div class="overflow-x-auto">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Provider</th>
+                <th>Role</th>
+                <th>Joined</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Users}}
+            {{template "user_row" .}}
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<p class="text-base-content/60 py-8 text-center">No users yet.</p>
+{{end}}
+{{end}}
+
+{{define "user_row"}}
+<!-- Governing: SPEC-0004 REQ "Admin Dashboard" — user row fragment for HTMX role toggle -->
+<tr id="user-{{.ID}}">
+    <td>
+        <div class="flex items-center gap-2">
+            <div class="avatar placeholder">
+                <div class="bg-neutral text-neutral-content rounded-full w-7">
+                    <span class="text-xs">{{slice .DisplayName 0 1}}</span>
+                </div>
+            </div>
+            <span>{{.DisplayName}}</span>
+        </div>
+    </td>
+    <td class="text-sm">{{.Email}}</td>
+    <td class="text-sm text-base-content/60">{{.Provider}}</td>
+    <td>
+        <!-- Governing: SPEC-0004 REQ "Admin Dashboard" — inline role toggle via HTMX -->
+        <select class="select select-bordered select-xs"
+                hx-put="/admin/users/{{.ID}}/role"
+                hx-target="#user-{{.ID}}"
+                hx-swap="outerHTML"
+                hx-vals='js:{role: event.target.value}'
+                hx-params="none"
+                hx-trigger="change">
+            <option value="user"{{if eq .Role "user"}} selected{{end}}>user</option>
+            <option value="admin"{{if eq .Role "admin"}} selected{{end}}>admin</option>
+        </select>
+    </td>
+    <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
+</tr>
 {{end}}

--- a/web/templates/pages/tags/detail.html
+++ b/web/templates/pages/tags/detail.html
@@ -1,6 +1,40 @@
 {{template "base" .}}
-{{define "title"}}Tag — Joe Links{{end}}
+
+{{define "title"}}{{if .Tag}}{{.Tag.Name}} — {{end}}Tags — Joe Links{{end}}
+
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Tag</h1>
-<p class="text-base-content/70">Tag detail coming soon.</p>
+<!-- Governing: SPEC-0004 REQ "Tag Browser" -->
+<div class="flex items-center gap-3 mb-6">
+    <a href="/dashboard/tags" class="btn btn-ghost btn-sm">← Tags</a>
+    {{if .Tag}}<h1 class="text-2xl font-bold">{{.Tag.Name}}</h1>{{end}}
+</div>
+
+{{if .Links}}
+<div class="overflow-x-auto">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Slug</th>
+                <th>Destination</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Links}}
+            <tr>
+                <td>
+                    <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
+                </td>
+                <td class="max-w-xs truncate text-sm">
+                    <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
+                </td>
+                <td class="text-sm text-base-content/70">{{.Description}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
+<p class="text-base-content/60 py-8 text-center">No links tagged with "{{if .Tag}}{{.Tag.Name}}{{end}}".</p>
+{{end}}
 {{end}}

--- a/web/templates/pages/tags/index.html
+++ b/web/templates/pages/tags/index.html
@@ -1,6 +1,28 @@
 {{template "base" .}}
+
 {{define "title"}}Tags — Joe Links{{end}}
+
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Tags</h1>
-<p class="text-base-content/70">Tag browser coming soon.</p>
+<!-- Governing: SPEC-0004 REQ "Tag Browser" -->
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">Tags</h1>
+</div>
+
+{{if .Tags}}
+<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+    {{range .Tags}}
+    <a href="/dashboard/tags/{{.Slug}}" class="card bg-base-200 shadow hover:shadow-md transition-shadow">
+        <div class="card-body p-4">
+            <h2 class="font-semibold">{{.Name}}</h2>
+            <p class="text-sm text-base-content/60">{{.Count}} {{if eq .Count 1}}link{{else}}links{{end}}</p>
+        </div>
+    </a>
+    {{end}}
+</div>
+{{else}}
+<div class="text-center py-16">
+    <p class="text-base-content/60 mb-4">No tags yet. Add tags when creating or editing a link.</p>
+    <a href="/dashboard/links/new" class="btn btn-primary btn-sm">Create a link</a>
+</div>
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

Implements the tag browser (with counts), tag detail view, and full admin views (dashboard, user management with role toggle, all-links list).

- **Tag browser** (`GET /dashboard/tags`): card grid of all tags with ≥1 link and link counts; `TagStore.ListWithCounts` uses `HAVING COUNT >= 1` to exclude zero-count tags
- **Tag detail** (`GET /dashboard/tags/{slug}`): table of all links bearing that tag via `LinkStore.ListByTag`
- **Admin dashboard** (`GET /admin`): stat cards showing total users and total links with navigation links
- **Admin users** (`GET /admin/users`): full user table with inline role toggle select using `hx-vals='js:...'` + `hx-trigger="change"` — `PUT /admin/users/{id}/role` returns updated `user_row` fragment via HTMX outerHTML swap
- **Admin links** (`GET /admin/links`): all links across all users
- `UserStore.ListAll`: all users ordered by display_name
- `UserStore.UpdateRole`: updates role, returns updated User
- `TagsHandler` now takes `LinkStore` for `Detail` method
- `AdminHandler` now takes `LinkStore` and `UserStore`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Verify `/dashboard/tags` shows tag cards with counts; zero-count tags absent
- [ ] Verify `/dashboard/tags/{slug}` shows filtered link list
- [ ] Verify `/admin` shows user/link stat cards
- [ ] Verify `/admin/users` shows user table with role select
- [ ] Verify role toggle fires PUT, row re-renders with new role selected
- [ ] Verify `user` role accessing `/admin/*` receives 403
- [ ] Verify `/admin/links` shows all links

Closes #19
Part of #4 (epic)
Governing: SPEC-0004 REQ "Tag Browser", "Admin Dashboard", ADR-0007

🤖 Generated with [Claude Code](https://claude.com/claude-code)