### PR TITLE
Links & Owner Endpoints (SPEC-0005)

### DIFF
--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -1,0 +1,491 @@
+// Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource", REQ "Co-Owner Management", ADR-0008
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// linksAPIHandler provides REST handlers for link management.
+// Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource"
+type linksAPIHandler struct {
+	links     *store.LinkStore
+	ownership *store.OwnershipStore
+	users     *store.UserStore
+}
+
+// registerLinkRoutes registers link and co-owner routes on r.
+// Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource", REQ "Co-Owner Management"
+func registerLinkRoutes(r chi.Router, links *store.LinkStore, ownership *store.OwnershipStore, users *store.UserStore) {
+	h := &linksAPIHandler{links: links, ownership: ownership, users: users}
+	r.Get("/links", h.List)
+	r.Post("/links", h.Create)
+	r.Get("/links/{id}", h.Get)
+	r.Put("/links/{id}", h.Update)
+	r.Delete("/links/{id}", h.Delete)
+	r.Get("/links/{id}/owners", h.ListOwners)
+	r.Post("/links/{id}/owners", h.AddOwner)
+	r.Delete("/links/{id}/owners/{uid}", h.RemoveOwner)
+}
+
+// List returns owned links for regular users, or all links for admins.
+// GET /api/v1/links
+// Governing: SPEC-0005 REQ "Links Collection"
+func (h *linksAPIHandler) List(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	var links []*store.Link
+	var err error
+
+	if user.Role == "admin" {
+		links, err = h.links.ListAll(r.Context())
+	} else {
+		links, err = h.links.ListByOwner(r.Context(), user.ID)
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links))}
+	for _, l := range links {
+		lr, err := h.toLinkResponse(r.Context(), l)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		resp.Links = append(resp.Links, lr)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Create creates a new link with the authenticated user as primary owner.
+// POST /api/v1/links
+// Governing: SPEC-0005 REQ "Links Collection"
+func (h *linksAPIHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	var req CreateLinkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body", "BAD_REQUEST")
+		return
+	}
+
+	if req.Slug == "" {
+		writeError(w, http.StatusBadRequest, "slug is required", "BAD_REQUEST")
+		return
+	}
+	if req.URL == "" {
+		writeError(w, http.StatusBadRequest, "url is required", "BAD_REQUEST")
+		return
+	}
+
+	// Validate slug format and reserved prefixes.
+	// Governing: SPEC-0005 REQ "Links Collection" — slug format [a-z0-9][a-z0-9\-]*[a-z0-9]
+	if err := store.ValidateSlugFormat(req.Slug); err != nil {
+		if errors.Is(err, store.ErrSlugReserved) {
+			writeError(w, http.StatusBadRequest, err.Error(), "INVALID_SLUG")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "slug must match [a-z0-9][a-z0-9-]*[a-z0-9]", "INVALID_SLUG")
+		return
+	}
+
+	link, err := h.links.Create(r.Context(), req.Slug, req.URL, user.ID, req.Title, req.Description)
+	if err != nil {
+		if errors.Is(err, store.ErrSlugTaken) {
+			writeError(w, http.StatusConflict, "slug already exists", "SLUG_CONFLICT")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	// Set tags if provided.
+	if len(req.Tags) > 0 {
+		if err := h.links.SetTags(r.Context(), link.ID, req.Tags); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+	}
+
+	lr, err := h.toLinkResponse(r.Context(), link)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, lr)
+}
+
+// Get returns a single link by ID. Owners and admins only.
+// GET /api/v1/links/{id}
+// Governing: SPEC-0005 REQ "Link Resource"
+func (h *linksAPIHandler) Get(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	lr, err := h.toLinkResponse(r.Context(), link)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, lr)
+}
+
+// Update modifies a link's url, title, description, and tags. Slug is immutable and ignored.
+// PUT /api/v1/links/{id}
+// Governing: SPEC-0005 REQ "Link Resource" — slug field MUST be ignored (immutable)
+func (h *linksAPIHandler) Update(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	var req UpdateLinkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body", "BAD_REQUEST")
+		return
+	}
+
+	if req.URL == "" {
+		writeError(w, http.StatusBadRequest, "url is required", "BAD_REQUEST")
+		return
+	}
+
+	updated, err := h.links.Update(r.Context(), link.ID, req.URL, req.Title, req.Description)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	// Update tags.
+	if err := h.links.SetTags(r.Context(), link.ID, req.Tags); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	lr, err := h.toLinkResponse(r.Context(), updated)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, lr)
+}
+
+// Delete removes a link. Owners and admins only.
+// DELETE /api/v1/links/{id}
+// Governing: SPEC-0005 REQ "Link Resource"
+func (h *linksAPIHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	if err := h.links.Delete(r.Context(), link.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListOwners returns all owners of a link.
+// GET /api/v1/links/{id}/owners
+// Governing: SPEC-0005 REQ "Co-Owner Management"
+func (h *linksAPIHandler) ListOwners(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	owners, err := h.ownership.ListOwnerUsers(link.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	resp := make([]OwnerResponse, 0, len(owners))
+	for _, o := range owners {
+		resp = append(resp, OwnerResponse{
+			ID:        o.ID,
+			Email:     o.Email,
+			IsPrimary: o.IsPrimary,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// AddOwner adds a co-owner to a link by email. Owners and admins only.
+// POST /api/v1/links/{id}/owners
+// Governing: SPEC-0005 REQ "Co-Owner Management"
+func (h *linksAPIHandler) AddOwner(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	var req AddOwnerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body", "BAD_REQUEST")
+		return
+	}
+	if req.Email == "" {
+		writeError(w, http.StatusBadRequest, "email is required", "BAD_REQUEST")
+		return
+	}
+
+	targetUser, err := h.users.GetByEmail(r.Context(), req.Email)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "user not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if err := h.links.AddOwner(r.Context(), link.ID, targetUser.ID); err != nil {
+		if errors.Is(err, store.ErrDuplicateOwner) {
+			writeError(w, http.StatusConflict, "user is already an owner", "DUPLICATE_OWNER")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, OwnerResponse{
+		ID:        targetUser.ID,
+		Email:     targetUser.Email,
+		IsPrimary: false,
+	})
+}
+
+// RemoveOwner removes a co-owner from a link. Primary owner cannot be removed.
+// DELETE /api/v1/links/{id}/owners/{uid}
+// Governing: SPEC-0005 REQ "Co-Owner Management" — primary owner MUST be protected
+func (h *linksAPIHandler) RemoveOwner(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "UNAUTHORIZED")
+		return
+	}
+
+	linkID := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), linkID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	if user.Role != "admin" {
+		isOwner, err := h.ownership.IsOwner(link.ID, user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		if !isOwner {
+			writeError(w, http.StatusForbidden, "forbidden", "FORBIDDEN")
+			return
+		}
+	}
+
+	ownerUID := chi.URLParam(r, "uid")
+	if err := h.links.RemoveOwner(r.Context(), link.ID, ownerUID); err != nil {
+		if errors.Is(err, store.ErrPrimaryOwnerImmutable) {
+			writeError(w, http.StatusBadRequest, "primary owner cannot be removed", "PRIMARY_OWNER_PROTECTED")
+			return
+		}
+		if errors.Is(err, store.ErrNotOwner) {
+			writeError(w, http.StatusNotFound, "owner not found", "NOT_FOUND")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// toLinkResponse converts a store.Link to an API LinkResponse, including owners and tags.
+func (h *linksAPIHandler) toLinkResponse(ctx context.Context, link *store.Link) (*LinkResponse, error) {
+	owners, err := h.ownership.ListOwnerUsers(link.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	ownerResponses := make([]OwnerResponse, 0, len(owners))
+	for _, o := range owners {
+		ownerResponses = append(ownerResponses, OwnerResponse{
+			ID:        o.ID,
+			Email:     o.Email,
+			IsPrimary: o.IsPrimary,
+		})
+	}
+
+	tags, err := h.links.ListTags(ctx, link.ID)
+	if err != nil {
+		return nil, err
+	}
+	tagNames := make([]string, 0, len(tags))
+	for _, t := range tags {
+		tagNames = append(tagNames, t.Name)
+	}
+
+	return &LinkResponse{
+		ID:          link.ID,
+		Slug:        link.Slug,
+		URL:         link.URL,
+		Title:       link.Title,
+		Description: link.Description,
+		Tags:        tagNames,
+		Owners:      ownerResponses,
+		CreatedAt:   link.CreatedAt,
+		UpdatedAt:   link.UpdatedAt,
+	}, nil
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -45,6 +45,10 @@ func NewAPIRouter(deps Deps) http.Handler {
 	// Governing: SPEC-0005 REQ "User Profile"
 	registerUserRoutes(r)
 
+	// Link and co-owner management routes.
+	// Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource", REQ "Co-Owner Management"
+	registerLinkRoutes(r, deps.LinkStore, deps.OwnershipStore, deps.UserStore)
+
 	return r
 }
 


### PR DESCRIPTION
## Summary
- Implements all link-related API endpoints in `internal/api/links.go`: `GET/POST /api/v1/links`, `GET/PUT/DELETE /api/v1/links/{id}`, `GET/POST /api/v1/links/{id}/owners`, `DELETE /api/v1/links/{id}/owners/{uid}`
- Admin users see all links via `ListAll`; non-admins see only owned links via `ListByOwner`
- Slug validation enforces `[a-z0-9][a-z0-9-]*[a-z0-9]` format and blocks reserved prefixes
- Primary owner removal is blocked with `400 PRIMARY_OWNER_PROTECTED`
- Slug field is ignored on `PUT` (immutable after creation)
- Tags are managed via `SetTags` on create and update

Closes #46
Part of #37
Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource", REQ "Co-Owner Management"

## Test plan
- [ ] Verify `GET /api/v1/links` returns owned links for regular users and all links for admins
- [ ] Verify `POST /api/v1/links` validates slug format and rejects reserved prefixes
- [ ] Verify `POST /api/v1/links` returns 409 on duplicate slug
- [ ] Verify `GET /api/v1/links/{id}` returns 403 for non-owner non-admin users
- [ ] Verify `PUT /api/v1/links/{id}` ignores slug field in request body
- [ ] Verify `DELETE /api/v1/links/{id}` returns 204 for owners/admins
- [ ] Verify `DELETE /api/v1/links/{id}/owners/{uid}` returns 400 PRIMARY_OWNER_PROTECTED for primary owner
- [ ] Verify `POST /api/v1/links/{id}/owners` adds co-owner by email

🤖 Generated with [Claude Code](https://claude.com/claude-code)