### PR TITLE
Swagger UI Endpoint & CI Freshness Check (SPEC-0007)

### DIFF
--- a/.github/workflows/swagger-freshness.yml
+++ b/.github/workflows/swagger-freshness.yml
@@ -1,0 +1,38 @@
+# Governing: SPEC-0007 REQ "Spec Freshness in CI", ADR-0010
+# Verifies that docs/swagger/ is up to date with handler annotations.
+# Fails if make swagger produces a diff (i.e., the spec is stale).
+name: Swagger Freshness
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  swagger-freshness:
+    name: Verify swagger spec is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install swag
+        run: go install github.com/swaggo/swag/cmd/swag@latest
+
+      - name: Regenerate swagger spec
+        run: make swagger
+
+      - name: Check for stale swagger files
+        # Governing: SPEC-0007 REQ "Spec Freshness in CI"
+        # If any docs/swagger/ file changed, the spec is stale and CI must fail.
+        run: |
+          if ! git diff --exit-code docs/swagger/; then
+            echo "::error::docs/swagger/ is stale. Run 'make swagger' and commit the result."
+            exit 1
+          fi

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/swaggo/files/v2 v2.0.0 // indirect
+	github.com/swaggo/http-swagger/v2 v2.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw=
+github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
+github.com/swaggo/http-swagger/v2 v2.0.2 h1:FKCdLsl+sFCx60KFsyM0rDarwiUSZ8DqbfSyIKC9OBg=
+github.com/swaggo/http-swagger/v2 v2.0.2/go.mod h1:r7/GBkAWIfK6E/OLnE8fXnviHiDeAHmgIyooa4xm3AQ=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -2,6 +2,7 @@
 // Governing: SPEC-0003 REQ "HTMX Theme Endpoint", ADR-0006
 // Governing: SPEC-0004 REQ "Route Registration and Priority", "Shared Base Layout"
 // Governing: SPEC-0005 REQ "API Router Mounting", ADR-0008
+// Governing: SPEC-0007 REQ "Swagger UI Endpoint", ADR-0010
 package handler
 
 import (
@@ -15,6 +16,8 @@ import (
 	"github.com/joestump/joe-links/internal/auth"
 	"github.com/joestump/joe-links/internal/store"
 	"github.com/joestump/joe-links/web"
+	_ "github.com/joestump/joe-links/docs/swagger"
+	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
 // Deps holds all dependencies required to build the HTTP router.
@@ -109,6 +112,10 @@ func NewRouter(deps Deps) http.Handler {
 		r.Put("/admin/users/{id}/role", admin.UpdateRole)
 		r.Get("/admin/links", admin.Links)
 	})
+
+	// Swagger UI — no auth required; MUST be before slug catch-all.
+	// Governing: SPEC-0007 REQ "Swagger UI Endpoint", REQ "Swagger UI Authorization"
+	r.Get("/api/docs/*", httpSwagger.WrapHandler)
 
 	// API sub-router at /api/v1 — must be before slug catch-all.
 	// Governing: SPEC-0005 REQ "API Router Mounting"


### PR DESCRIPTION
## Summary

- Registers `GET /api/docs/*` using `httpSwagger.WrapHandler` (no auth required, before slug catch-all)
- Adds `http-swagger/v2` and `swaggo/files/v2` runtime dependencies
- Creates `.github/workflows/swagger-freshness.yml` to fail CI if `make swagger` produces uncommitted changes

## Details

**`internal/handler/router.go`**: Added `httpSwagger.WrapHandler` at `/api/docs/` with blank import of `docs/swagger` package. Route is registered before the `/api/v1` mount and slug catch-all, so it takes priority. No authentication required per spec.

**`.github/workflows/swagger-freshness.yml`**: Installs `swag`, runs `make swagger`, then `git diff --exit-code docs/swagger/`. Fails with an actionable error message if the spec is stale.

## Test plan

- [ ] `GET /api/docs/` returns 200 with Swagger UI HTML
- [ ] `GET /api/docs/swagger.json` returns the OpenAPI JSON
- [ ] The Authorize dialog shows BearerToken scheme
- [ ] CI fails when annotations are modified but `make swagger` is not re-run

Closes #51
Part of #39 (epic)
Governing: SPEC-0007 REQ "Swagger UI Endpoint", REQ "Swagger UI Authorization", REQ "Spec Freshness in CI", ADR-0010

🤖 Generated with [Claude Code](https://claude.com/claude-code)