### PR TITLE
Keywords data model, KeywordStore, and public API endpoint

### DIFF
--- a/cmd/joe-links/serve.go
+++ b/cmd/joe-links/serve.go
@@ -47,6 +47,7 @@ func newServeCmd() *cobra.Command {
 			tagStore := store.NewTagStore(database)
 			linkStore := store.NewLinkStore(database, ownershipStore, tagStore)
 			tokenStore := auth.NewSQLTokenStore(database)
+			keywordStore := store.NewKeywordStore(database)
 
 			authHandlers := auth.NewHandlers(oidcProvider, sessionManager, userStore, cfg.AdminEmail, !cfg.InsecureCookies)
 			authMiddleware := auth.NewMiddleware(sessionManager, userStore)
@@ -60,6 +61,7 @@ func newServeCmd() *cobra.Command {
 				TagStore:       tagStore,
 				UserStore:      userStore,
 				TokenStore:     tokenStore,
+				KeywordStore:   keywordStore,
 			})
 
 			log.Printf("listening on %s", cfg.HTTP.Addr)

--- a/internal/api/keywords.go
+++ b/internal/api/keywords.go
@@ -1,0 +1,27 @@
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// registerKeywordRoutes registers the public /keywords endpoint.
+// No auth required -- the browser extension calls this without a token.
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+func registerKeywordRoutes(r chi.Router, keywords *store.KeywordStore) {
+	r.Get("/keywords", func(w http.ResponseWriter, r *http.Request) {
+		list, err := keywords.List(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to list keywords", "INTERNAL_ERROR")
+			return
+		}
+		names := make([]string, len(list))
+		for i, k := range list {
+			names[i] = k.Keyword
+		}
+		writeJSON(w, http.StatusOK, names)
+	})
+}

--- a/internal/db/migrations/00008_create_keywords.sql
+++ b/internal/db/migrations/00008_create_keywords.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS keywords (
+    id          TEXT PRIMARY KEY,
+    keyword     TEXT NOT NULL UNIQUE,
+    url_template TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS keywords;

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -30,6 +30,7 @@ type Deps struct {
 	TagStore       *store.TagStore
 	UserStore      *store.UserStore
 	TokenStore     auth.TokenStore
+	KeywordStore   *store.KeywordStore
 }
 
 // NewRouter assembles the full chi router with all middleware and routes.
@@ -128,6 +129,7 @@ func NewRouter(deps Deps) http.Handler {
 		OwnershipStore:   deps.OwnershipStore,
 		TagStore:         deps.TagStore,
 		UserStore:        deps.UserStore,
+		KeywordStore:     deps.KeywordStore,
 	})
 	r.Mount("/api/v1", apiRouter)
 

--- a/internal/store/keyword_store.go
+++ b/internal/store/keyword_store.go
@@ -1,0 +1,106 @@
+// Governing: ADR-0011 REQ "Keyword Host Discovery"
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// Keyword represents a row in the keywords table.
+type Keyword struct {
+	ID          string    `db:"id"`
+	Keyword     string    `db:"keyword"`
+	URLTemplate string    `db:"url_template"`
+	Description string    `db:"description"`
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+// KeywordStore is the sqlx-backed store for keyword operations.
+// Governing: ADR-0011 REQ "Keyword Host Discovery"
+type KeywordStore struct {
+	db *sqlx.DB
+}
+
+func NewKeywordStore(db *sqlx.DB) *KeywordStore {
+	return &KeywordStore{db: db}
+}
+
+// List returns all keywords ordered by keyword name.
+func (s *KeywordStore) List(ctx context.Context) ([]*Keyword, error) {
+	var keywords []*Keyword
+	err := s.db.SelectContext(ctx, &keywords, `SELECT * FROM keywords ORDER BY keyword ASC`)
+	if err != nil {
+		return nil, err
+	}
+	return keywords, nil
+}
+
+// GetByKeyword returns the keyword matching the given keyword string, or ErrNotFound.
+func (s *KeywordStore) GetByKeyword(ctx context.Context, keyword string) (*Keyword, error) {
+	var k Keyword
+	err := s.db.GetContext(ctx, &k, `SELECT * FROM keywords WHERE keyword = ?`, keyword)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+// Create inserts a new keyword and returns it.
+func (s *KeywordStore) Create(ctx context.Context, keyword, urlTemplate, description string) (*Keyword, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO keywords (id, keyword, url_template, description, created_at) VALUES (?, ?, ?, ?, ?)
+	`, id, keyword, urlTemplate, description, now)
+	if err != nil {
+		return nil, err
+	}
+	return &Keyword{ID: id, Keyword: keyword, URLTemplate: urlTemplate, Description: description, CreatedAt: now}, nil
+}
+
+// Update updates an existing keyword and returns it.
+func (s *KeywordStore) Update(ctx context.Context, id, keyword, urlTemplate, description string) (*Keyword, error) {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE keywords SET keyword = ?, url_template = ?, description = ? WHERE id = ?
+	`, keyword, urlTemplate, description, id)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if rows == 0 {
+		return nil, ErrNotFound
+	}
+	// Re-fetch to get the full row including created_at.
+	var k Keyword
+	err = s.db.GetContext(ctx, &k, `SELECT * FROM keywords WHERE id = ?`, id)
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+// Delete removes a keyword by ID.
+func (s *KeywordStore) Delete(ctx context.Context, id string) error {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM keywords WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -39,3 +39,13 @@ type TagStoreIface interface {
 	GetBySlug(ctx context.Context, slug string) (*Tag, error)
 	ListAll(ctx context.Context) ([]*Tag, error)
 }
+
+// KeywordStoreIface exposes keyword operations.
+// Governing: ADR-0011 REQ "Keyword Host Discovery"
+type KeywordStoreIface interface {
+	List(ctx context.Context) ([]*Keyword, error)
+	GetByKeyword(ctx context.Context, keyword string) (*Keyword, error)
+	Create(ctx context.Context, keyword, urlTemplate, description string) (*Keyword, error)
+	Update(ctx context.Context, id, keyword, urlTemplate, description string) (*Keyword, error)
+	Delete(ctx context.Context, id string) error
+}


### PR DESCRIPTION
Implements the server-side foundation for keyword host routing.

## Changes
- `internal/db/migrations/00008_create_keywords.sql` — keywords table
- `internal/store/keyword_store.go` — KeywordStore with List/GetByKeyword/Create/Update/Delete
- `internal/api/keywords.go` — public GET /api/v1/keywords endpoint
- `internal/api/router.go` — KeywordStore in Deps, public route group
- `internal/handler/router.go` — KeywordStore in handler Deps, passed to API router
- `internal/store/store.go` — KeywordStoreIface interface
- `cmd/joe-links/serve.go` — wire KeywordStore

Closes #66
Part of #65 (epic)
Governing: SPEC-0008, ADR-0011