### PR TITLE
Keyword host resolver — Host-header routing with template substitution

### DIFF
--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -137,7 +137,7 @@ func NewRouter(deps Deps) http.Handler {
 	// Resolver does not require auth (links are publicly accessible).
 	// Uses OptionalUser so the 404 page can offer "Create this link" when logged in.
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — catch-all AFTER named routes
-	resolver := NewResolveHandler(deps.LinkStore)
+	resolver := NewResolveHandler(deps.LinkStore, deps.KeywordStore)
 	r.With(deps.AuthMiddleware.OptionalUser).Get("/{slug}", resolver.Resolve)
 
 	return r


### PR DESCRIPTION
Updates the slug resolver to check the Host header against the keywords table before falling through to normal slug lookup.

## Changes
- `internal/handler/resolve.go`: checks Host header via KeywordStore.GetByKeyword, substitutes {slug} in url_template, 302 redirect on match
- `internal/handler/router.go`: passes KeywordStore to NewResolveHandler

Closes #67
Part of #65 (epic)
Governing: SPEC-0008, ADR-0011