### PR TITLE
Add admin UI for keyword template CRUD (#68)

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -11,20 +11,22 @@ import (
 
 // AdminHandler serves admin views.
 type AdminHandler struct {
-	links *store.LinkStore
-	users *store.UserStore
+	links    *store.LinkStore
+	users    *store.UserStore
+	keywords *store.KeywordStore
 }
 
 // NewAdminHandler creates a new AdminHandler.
-func NewAdminHandler(ls *store.LinkStore, us *store.UserStore) *AdminHandler {
-	return &AdminHandler{links: ls, users: us}
+func NewAdminHandler(ls *store.LinkStore, us *store.UserStore, ks *store.KeywordStore) *AdminHandler {
+	return &AdminHandler{links: ls, users: us, keywords: ks}
 }
 
 // AdminDashboardPage is the template data for the admin overview.
 type AdminDashboardPage struct {
 	BasePage
-	UserCount int
-	LinkCount int
+	UserCount    int
+	LinkCount    int
+	KeywordCount int
 }
 
 // AdminUsersPage is the template data for the user management list.
@@ -45,10 +47,12 @@ func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	allUsers, _ := h.users.ListAll(r.Context())
 	allLinks, _ := h.links.ListAll(r.Context())
+	allKeywords, _ := h.keywords.List(r.Context())
 	data := AdminDashboardPage{
-		BasePage:  BasePage{Theme: themeFromRequest(r), User: user},
-		UserCount: len(allUsers),
-		LinkCount: len(allLinks),
+		BasePage:     BasePage{Theme: themeFromRequest(r), User: user},
+		UserCount:    len(allUsers),
+		LinkCount:    len(allLinks),
+		KeywordCount: len(allKeywords),
 	}
 	render(w, "admin/dashboard.html", data)
 }

--- a/internal/handler/keywords.go
+++ b/internal/handler/keywords.go
@@ -1,0 +1,114 @@
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+package handler
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+var keywordRE = regexp.MustCompile(`^[a-z][a-z0-9\-]*$`)
+
+// KeywordsHandler serves admin keyword CRUD views.
+type KeywordsHandler struct {
+	keywords *store.KeywordStore
+}
+
+// NewKeywordsHandler creates a new KeywordsHandler.
+func NewKeywordsHandler(ks *store.KeywordStore) *KeywordsHandler {
+	return &KeywordsHandler{keywords: ks}
+}
+
+// AdminKeywordsPage is the template data for the keywords list.
+type AdminKeywordsPage struct {
+	BasePage
+	Keywords []*store.Keyword
+	Error    string
+}
+
+// Index renders the keyword management list.
+// GET /admin/keywords
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+func (h *KeywordsHandler) Index(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	keywords, _ := h.keywords.List(r.Context())
+	data := AdminKeywordsPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		Keywords: keywords,
+	}
+	render(w, "admin/keywords.html", data)
+}
+
+// Create processes the inline keyword creation form.
+// POST /admin/keywords
+// Validates: keyword non-empty, lowercase alphanumeric+hyphens ([a-z][a-z0-9-]*)
+// Validates: url_template contains "{slug}"
+// On error: re-render keyword_list partial with error via HTMX
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+func (h *KeywordsHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	keyword := strings.TrimSpace(r.FormValue("keyword"))
+	urlTemplate := strings.TrimSpace(r.FormValue("url_template"))
+	description := strings.TrimSpace(r.FormValue("description"))
+
+	if keyword == "" || urlTemplate == "" {
+		h.renderList(w, r, user, "Keyword and URL template are required.")
+		return
+	}
+
+	if !keywordRE.MatchString(keyword) {
+		h.renderList(w, r, user, "Keyword must be lowercase letters, digits, and hyphens (e.g. jira, my-tool).")
+		return
+	}
+
+	if !strings.Contains(urlTemplate, "{slug}") {
+		h.renderList(w, r, user, "URL template must contain {slug} placeholder.")
+		return
+	}
+
+	_, err := h.keywords.Create(r.Context(), keyword, urlTemplate, description)
+	if err != nil {
+		h.renderList(w, r, user, "A keyword with that name already exists.")
+		return
+	}
+
+	h.renderList(w, r, user, "")
+}
+
+// Delete removes a keyword. Returns empty 200 so HTMX swaps out the row.
+// DELETE /admin/keywords/{id}
+// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+func (h *KeywordsHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	if err := h.keywords.Delete(r.Context(), id); err != nil {
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// renderList re-renders the keyword_list partial (or full page for non-HTMX).
+func (h *KeywordsHandler) renderList(w http.ResponseWriter, r *http.Request, user *store.User, errMsg string) {
+	keywords, _ := h.keywords.List(r.Context())
+	data := AdminKeywordsPage{
+		BasePage: BasePage{Theme: themeFromRequest(r), User: user},
+		Keywords: keywords,
+		Error:    errMsg,
+	}
+	if isHTMX(r) {
+		renderPageFragment(w, "admin/keywords.html", "keyword_list", data)
+		return
+	}
+	render(w, "admin/keywords.html", data)
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -104,7 +104,8 @@ func NewRouter(deps Deps) http.Handler {
 
 	// Admin routes (require admin role)
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — admin group with RequireAdmin
-	admin := NewAdminHandler(deps.LinkStore, deps.UserStore)
+	admin := NewAdminHandler(deps.LinkStore, deps.UserStore, deps.KeywordStore)
+	keywordsHandler := NewKeywordsHandler(deps.KeywordStore)
 	r.Group(func(r chi.Router) {
 		r.Use(deps.AuthMiddleware.RequireAuth)
 		r.Use(deps.AuthMiddleware.RequireRole("admin"))
@@ -112,6 +113,11 @@ func NewRouter(deps Deps) http.Handler {
 		r.Get("/admin/users", admin.Users)
 		r.Put("/admin/users/{id}/role", admin.UpdateRole)
 		r.Get("/admin/links", admin.Links)
+
+		// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
+		r.Get("/admin/keywords", keywordsHandler.Index)
+		r.Post("/admin/keywords", keywordsHandler.Create)
+		r.Delete("/admin/keywords/{id}", keywordsHandler.Delete)
 	})
 
 	// Swagger UI — no auth required; MUST be before slug catch-all.

--- a/internal/store/keyword_store.go
+++ b/internal/store/keyword_store.go
@@ -39,6 +39,19 @@ func (s *KeywordStore) List(ctx context.Context) ([]*Keyword, error) {
 	return keywords, nil
 }
 
+// GetByID returns the keyword matching the given ID, or ErrNotFound.
+func (s *KeywordStore) GetByID(ctx context.Context, id string) (*Keyword, error) {
+	var k Keyword
+	err := s.db.GetContext(ctx, &k, `SELECT * FROM keywords WHERE id = ?`, id)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
 // GetByKeyword returns the keyword matching the given keyword string, or ErrNotFound.
 func (s *KeywordStore) GetByKeyword(ctx context.Context, keyword string) (*Keyword, error) {
 	var k Keyword

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,7 @@ type TagStoreIface interface {
 // Governing: ADR-0011 REQ "Keyword Host Discovery"
 type KeywordStoreIface interface {
 	List(ctx context.Context) ([]*Keyword, error)
+	GetByID(ctx context.Context, id string) (*Keyword, error)
 	GetByKeyword(ctx context.Context, keyword string) (*Keyword, error)
 	Create(ctx context.Context, keyword, urlTemplate, description string) (*Keyword, error)
 	Update(ctx context.Context, id, keyword, urlTemplate, description string) (*Keyword, error)

--- a/web/templates/pages/admin/dashboard.html
+++ b/web/templates/pages/admin/dashboard.html
@@ -6,19 +6,26 @@
 <!-- Governing: SPEC-0004 REQ "Admin Dashboard" -->
 <h1 class="text-2xl font-bold mb-6">Admin Dashboard</h1>
 
-<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-md">
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-2xl">
     <div class="stat bg-base-200 rounded-box shadow">
         <div class="stat-title">Total Users</div>
         <div class="stat-value text-primary">{{.UserCount}}</div>
         <div class="stat-actions">
-            <a href="/admin/users" class="btn btn-sm btn-ghost">Manage →</a>
+            <a href="/admin/users" class="btn btn-sm btn-ghost">Manage &rarr;</a>
         </div>
     </div>
     <div class="stat bg-base-200 rounded-box shadow">
         <div class="stat-title">Total Links</div>
         <div class="stat-value text-primary">{{.LinkCount}}</div>
         <div class="stat-actions">
-            <a href="/admin/links" class="btn btn-sm btn-ghost">View →</a>
+            <a href="/admin/links" class="btn btn-sm btn-ghost">View &rarr;</a>
+        </div>
+    </div>
+    <div class="stat bg-base-200 rounded-box shadow">
+        <div class="stat-title">Keywords</div>
+        <div class="stat-value text-primary">{{.KeywordCount}}</div>
+        <div class="stat-actions">
+            <a href="/admin/keywords" class="btn btn-sm btn-ghost">Manage &rarr;</a>
         </div>
     </div>
 </div>

--- a/web/templates/pages/admin/keywords.html
+++ b/web/templates/pages/admin/keywords.html
@@ -1,0 +1,64 @@
+{{template "base" .}}
+
+{{define "title"}}Keywords — Admin — Joe Links{{end}}
+
+{{define "content"}}
+<!-- Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011 -->
+<div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">Keyword Templates</h1>
+    <a href="/admin" class="btn btn-ghost btn-sm">&larr; Admin</a>
+</div>
+
+<!-- Create form -->
+<form hx-post="/admin/keywords" hx-target="#keyword-list" hx-swap="outerHTML" class="card bg-base-200 p-4 mb-6">
+    <div class="flex gap-3 flex-wrap">
+        <input type="text" name="keyword" placeholder="keyword (e.g. jira)"
+               class="input input-bordered w-32 font-mono" required />
+        <input type="text" name="url_template" placeholder="https://example.com/search?q={slug}"
+               class="input input-bordered flex-1" required />
+        <input type="text" name="description" placeholder="Description (optional)"
+               class="input input-bordered w-48" />
+        <button type="submit" class="btn btn-primary">Add</button>
+    </div>
+    <p class="text-xs text-base-content/60 mt-1">URL template must contain <code>{slug}</code></p>
+</form>
+
+<!-- Keyword list -->
+<div id="keyword-list">
+    {{template "keyword_list" .}}
+</div>
+{{end}}
+
+{{define "keyword_list"}}
+{{if .Error}}
+<div class="alert alert-error mb-4"><span>{{.Error}}</span></div>
+{{end}}
+<table class="table w-full">
+    <thead>
+        <tr>
+            <th>Keyword</th>
+            <th>URL Template</th>
+            <th>Description</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {{range .Keywords}}
+    <tr id="keyword-{{.ID}}">
+        <td><code class="font-mono font-semibold">{{.Keyword}}</code></td>
+        <td class="text-sm font-mono">{{.URLTemplate}}</td>
+        <td class="text-sm text-base-content/70">{{.Description}}</td>
+        <td>
+            <button class="btn btn-ghost btn-xs text-error"
+                    hx-delete="/admin/keywords/{{.ID}}"
+                    hx-target="#keyword-{{.ID}}"
+                    hx-swap="outerHTML"
+                    hx-confirm="Delete keyword '{{.Keyword}}'?">Delete</button>
+        </td>
+    </tr>
+    {{else}}
+    <tr><td colspan="4" class="text-center text-base-content/50">No keywords configured.</td></tr>
+    {{end}}
+    </tbody>
+</table>
+{{end}}


### PR DESCRIPTION
Adds admin-only HTMX pages for managing keyword host templates.

## Changes
- `internal/handler/keywords.go`: KeywordsHandler with Index/Create/Delete + validation
- `web/templates/pages/admin/keywords.html`: keyword list + inline create form with `keyword_list` HTMX partial
- `internal/handler/router.go`: registered admin keyword routes
- `internal/handler/admin.go`: admin dashboard updated with keyword count stat card
- `internal/store/keyword_store.go`: added `GetByID` method
- `internal/store/store.go`: updated `KeywordStoreIface` with `GetByID`

## Validation
- Keyword format: `[a-z][a-z0-9-]*` (lowercase alphanumeric + hyphens)
- URL template must contain `{slug}` placeholder
- Duplicate keyword names rejected with inline error

Closes #68
Part of #65 (epic)
Governing: ADR-0011