### PR TITLE
Add $varname URL validation, link form hint, and API passthrough

### DIFF
--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -1,4 +1,5 @@
 // Governing: SPEC-0005 REQ "Links Collection", REQ "Link Resource", REQ "Co-Owner Management", ADR-0008
+// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
 package api
 
 import (
@@ -129,6 +130,12 @@ func (h *linksAPIHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeError(w, http.StatusBadRequest, "slug must match [a-z0-9][a-z0-9-]*[a-z0-9]", "INVALID_SLUG")
+		return
+	}
+
+	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
+	if err := store.ValidateURLVariables(req.URL); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error(), "INVALID_URL")
 		return
 	}
 
@@ -272,6 +279,12 @@ func (h *linksAPIHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	if req.URL == "" {
 		writeError(w, http.StatusBadRequest, "url is required", "BAD_REQUEST")
+		return
+	}
+
+	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
+	if err := store.ValidateURLVariables(req.URL); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error(), "INVALID_URL")
 		return
 	}
 

--- a/web/templates/pages/links/edit.html
+++ b/web/templates/pages/links/edit.html
@@ -25,10 +25,13 @@
                     </label>
                 </div>
 
+                <!-- Governing: SPEC-0009 REQ "Link Creation and Editing UI", ADR-0013 -->
                 <div class="form-control mb-4">
                     <label class="label"><span class="label-text">Destination URL <span class="text-error">*</span></span></label>
-                    <input type="url" name="url" class="input input-bordered"
-                        required value="{{if .Form.URL}}{{.Form.URL}}{{else}}{{.Link.URL}}{{end}}">
+                    <input type="url" name="url" id="url-input" class="input input-bordered"
+                        required value="{{if .Form.URL}}{{.Form.URL}}{{else}}{{.Link.URL}}{{end}}"
+                        oninput="updateVarHint()">
+                    <div id="url-var-hint" class="mt-1 min-h-[1.25rem]"></div>
                 </div>
 
                 <div class="form-control mb-4">
@@ -61,4 +64,26 @@
         </div>
     </div>
 </div>
+
+<script>
+// Governing: SPEC-0009 REQ "Link Creation and Editing UI", ADR-0013
+function updateVarHint() {
+    var input = document.getElementById('url-input');
+    var hint = document.getElementById('url-var-hint');
+    var re = /\$[a-z][a-z0-9_]*/g;
+    var matches = input.value.match(re);
+    if (!matches || matches.length === 0) {
+        hint.innerHTML = '';
+        return;
+    }
+    var names = matches.map(function(m){ return m.substring(1); });
+    var slugEl = document.querySelector('input[name="slug"]');
+    var slugVal = '{{.Link.Slug}}';
+    var example = 'go/' + slugVal + '/' + names.map(function(n){ return '&lt;' + n + '&gt;'; }).join('/');
+    hint.innerHTML = '<span class="text-xs text-info">' +
+        'Variables detected: ' + names.map(function(n){ return '<code class="badge badge-sm badge-outline">$' + n + '</code>'; }).join(' ') +
+        ' — navigate as <code class="font-mono">' + example + '</code></span>';
+}
+document.addEventListener('DOMContentLoaded', updateVarHint);
+</script>
 {{end}}

--- a/web/templates/pages/links/new.html
+++ b/web/templates/pages/links/new.html
@@ -41,6 +41,7 @@
                     <div id="slug-status" class="mt-1 min-h-[1.25rem]"></div>
                 </div>
 
+                <!-- Governing: SPEC-0009 REQ "Link Creation and Editing UI", ADR-0013 -->
                 <div class="form-control mb-4">
                     <label class="label">
                         <span class="label-text">Destination URL <span class="text-error">*</span></span>
@@ -48,11 +49,14 @@
                     <input
                         type="url"
                         name="url"
+                        id="url-input"
                         class="input input-bordered"
                         placeholder="https://example.com/very/long/url"
                         required
                         value="{{.Form.URL}}"
+                        oninput="updateVarHint()"
                     >
+                    <div id="url-var-hint" class="mt-1 min-h-[1.25rem]"></div>
                 </div>
 
                 <div class="form-control mb-4">
@@ -127,5 +131,25 @@ function addTag(name) {
     document.getElementById('tag-suggestions').innerHTML = '';
     input.focus();
 }
+
+// Governing: SPEC-0009 REQ "Link Creation and Editing UI", ADR-0013
+function updateVarHint() {
+    var input = document.getElementById('url-input');
+    var hint = document.getElementById('url-var-hint');
+    var re = /\$[a-z][a-z0-9_]*/g;
+    var matches = input.value.match(re);
+    if (!matches || matches.length === 0) {
+        hint.innerHTML = '';
+        return;
+    }
+    var names = matches.map(function(m){ return m.substring(1); });
+    var slug = document.querySelector('input[name="slug"]');
+    var slugVal = slug ? slug.value || 'my-link' : 'my-link';
+    var example = 'go/' + slugVal + '/' + names.map(function(n){ return '&lt;' + n + '&gt;'; }).join('/');
+    hint.innerHTML = '<span class="text-xs text-info">' +
+        'Variables detected: ' + names.map(function(n){ return '<code class="badge badge-sm badge-outline">$' + n + '</code>'; }).join(' ') +
+        ' — navigate as <code class="font-mono">' + example + '</code></span>';
+}
+document.addEventListener('DOMContentLoaded', updateVarHint);
 </script>
 {{end}}


### PR DESCRIPTION
## Summary

Establishes the `$varname` syntax contract for URL variable substitution (SPEC-0009, ADR-0013):

- **Validation**: `ValidateURLVariables()` in `internal/store/validate.go` enforces that `$varname` placeholders (matching `\$[a-z][a-z0-9_]*`) are unique within a URL template. Duplicate variable names are rejected at save time with `ErrDuplicateVariable`.
- **Web handlers**: Both `Create` and `Update` in `internal/handler/links.go` call the new validation before persisting.
- **API handlers**: Both `Create` and `Update` in `internal/api/links.go` call the new validation, returning 400 with code `INVALID_URL` on duplicates.
- **Form hint**: Inline JS in `new.html` and `edit.html` detects `$varname` in the URL field and displays detected variable names with an example navigation path (e.g., `go/github/<username>`). Hidden for static URLs.
- **API passthrough**: The API returns URL templates with `$varname` as-is — no resolution or special handling (confirmed by new integration tests).

## Test plan

- [x] `TestValidateURLVariables` — 12 cases covering static URLs, single var, multiple vars, and duplicate rejection
- [x] `TestLinks_Create_VariableURL_Passthrough` — API creates link with `$username` and returns template verbatim
- [x] `TestLinks_Create_DuplicateVariable_Rejected` — API rejects `$foo/$foo` with 400
- [x] `TestLinks_Get_VariableURL_Passthrough` — API GET returns `$query/$page` template unchanged
- [x] Full test suite passes (`go test ./...`)

Closes #75
Part of #74 (epic)
Governing: SPEC-0009, ADR-0013

🤖 Generated with [Claude Code](https://claude.com/claude-code)