### PR TITLE
Add HTMX modal system for link forms and delete confirmations

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -102,3 +102,22 @@ func (h *AdminHandler) Links(w http.ResponseWriter, r *http.Request) {
 	}
 	render(w, "admin/links.html", data)
 }
+
+// ConfirmDeleteUser renders the delete confirmation modal for a user.
+// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+func (h *AdminHandler) ConfirmDeleteUser(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	target, err := h.users.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := ConfirmDeleteData{
+		Name:      target.DisplayName,
+		DeleteURL: "/admin/users/" + id,
+		Target:    "#user-" + id,
+	}
+	renderFragment(w, "confirm_delete", data)
+}

--- a/internal/handler/keywords.go
+++ b/internal/handler/keywords.go
@@ -98,6 +98,26 @@ func (h *KeywordsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// ConfirmDelete renders the delete confirmation modal for a keyword.
+// GET /admin/keywords/{id}/confirm-delete
+// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+func (h *KeywordsHandler) ConfirmDelete(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	kw, err := h.keywords.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := ConfirmDeleteData{
+		Name:      kw.Keyword,
+		DeleteURL: "/admin/keywords/" + id,
+		Target:    "#keyword-" + id,
+	}
+	renderFragment(w, "confirm_delete", data)
+}
+
 // renderList re-renders the keyword_list partial (or full page for non-HTMX).
 func (h *KeywordsHandler) renderList(w http.ResponseWriter, r *http.Request, user *store.User, errMsg string) {
 	keywords, _ := h.keywords.List(r.Context())

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -87,6 +87,8 @@ func NewRouter(deps Deps) http.Handler {
 		r.Post("/dashboard/links", links.Create)
 		r.Get("/dashboard/links/{id}", links.Detail)
 		r.Get("/dashboard/links/{id}/edit", links.Edit)
+		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+		r.Get("/dashboard/links/{id}/confirm-delete", links.ConfirmDelete)
 		r.Put("/dashboard/links/{id}", links.Update)
 		r.Delete("/dashboard/links/{id}", links.Delete)
 		r.Post("/dashboard/links/{id}/owners", links.AddOwner)
@@ -99,6 +101,8 @@ func NewRouter(deps Deps) http.Handler {
 		// Governing: SPEC-0006 REQ "Token Management Web UI"
 		r.Get("/dashboard/settings/tokens", tokensWeb.Index)
 		r.Post("/dashboard/settings/tokens", tokensWeb.Create)
+		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+		r.Get("/dashboard/settings/tokens/{id}/confirm-revoke", tokensWeb.ConfirmRevoke)
 		r.Delete("/dashboard/settings/tokens/{id}", tokensWeb.Revoke)
 	})
 
@@ -111,12 +115,16 @@ func NewRouter(deps Deps) http.Handler {
 		r.Use(deps.AuthMiddleware.RequireRole("admin"))
 		r.Get("/admin", admin.Dashboard)
 		r.Get("/admin/users", admin.Users)
+		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+		r.Get("/admin/users/{id}/confirm-delete", admin.ConfirmDeleteUser)
 		r.Put("/admin/users/{id}/role", admin.UpdateRole)
 		r.Get("/admin/links", admin.Links)
 
 		// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
 		r.Get("/admin/keywords", keywordsHandler.Index)
 		r.Post("/admin/keywords", keywordsHandler.Create)
+		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+		r.Get("/admin/keywords/{id}/confirm-delete", keywordsHandler.ConfirmDelete)
 		r.Delete("/admin/keywords/{id}", keywordsHandler.Delete)
 	})
 

--- a/internal/handler/tokens.go
+++ b/internal/handler/tokens.go
@@ -145,6 +145,35 @@ func (h *TokensHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 	render(w, "tokens.html", data)
 }
 
+// ConfirmRevoke renders the delete confirmation modal for a token.
+// GET /dashboard/settings/tokens/{id}/confirm-revoke
+// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+func (h *TokensHandler) ConfirmRevoke(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	tokenID := chi.URLParam(r, "id")
+
+	// Verify the token belongs to this user by listing their tokens
+	records, _ := h.tokens.ListByUser(r.Context(), user.ID)
+	var tokenName string
+	for _, rec := range records {
+		if rec.ID == tokenID {
+			tokenName = rec.Name
+			break
+		}
+	}
+	if tokenName == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := ConfirmDeleteData{
+		Name:      tokenName,
+		DeleteURL: "/dashboard/settings/tokens/" + tokenID,
+		Target:    "#token-content",
+	}
+	renderFragment(w, "confirm_delete", data)
+}
+
 func (h *TokensHandler) renderWithError(w http.ResponseWriter, r *http.Request, user *store.User, errMsg string) {
 	records, _ := h.tokens.ListByUser(r.Context(), user.ID)
 	data := TokensPage{

--- a/web/templates/pages/admin/keywords.html
+++ b/web/templates/pages/admin/keywords.html
@@ -49,11 +49,11 @@
         <td class="text-sm font-mono">{{.URLTemplate}}</td>
         <td class="text-sm text-base-content/70">{{.Description}}</td>
         <td>
+            <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
             <button class="btn btn-ghost btn-xs text-error"
-                    hx-delete="/admin/keywords/{{.ID}}"
-                    hx-target="#keyword-{{.ID}}"
-                    hx-swap="outerHTML"
-                    hx-confirm="Delete keyword '{{.Keyword}}'?">Delete</button>
+                    hx-get="/admin/keywords/{{.ID}}/confirm-delete"
+                    hx-target="#modal"
+                    hx-swap="innerHTML">Delete</button>
         </td>
     </tr>
     {{else}}

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -5,7 +5,11 @@
 {{define "content"}}
 <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">My Links</h1>
-    <a href="/dashboard/links/new" class="btn btn-primary btn-sm">+ New link</a>
+    <!-- Governing: SPEC-0013 REQ "Create/Edit Link Form as HTMX Modal" -->
+    <button class="btn btn-primary btn-sm"
+            hx-get="/dashboard/links/new"
+            hx-target="#modal"
+            hx-swap="innerHTML">+ New link</button>
 </div>
 
 <!-- Governing: SPEC-0004 REQ "User Dashboard" — search input with HTMX debounce -->
@@ -42,7 +46,12 @@
 </div>
 {{end}}
 
-<div id="link-list">
+<!-- Governing: SPEC-0013 REQ "Create/Edit Link Form as HTMX Modal" — refresh on linkCreated/linkUpdated events -->
+<div id="link-list"
+     hx-get="/dashboard"
+     hx-trigger="linkCreated from:body, linkUpdated from:body"
+     hx-target="#link-list"
+     hx-swap="innerHTML">
 {{template "link_list" .}}
 </div>
 {{end}}

--- a/web/templates/partials/confirm_delete.html
+++ b/web/templates/partials/confirm_delete.html
@@ -1,0 +1,25 @@
+{{/* Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" */}}
+{{define "confirm_delete"}}
+<dialog id="confirm-modal" class="modal modal-open">
+    <div class="modal-box">
+        <h3 class="font-bold text-lg">Delete '{{.Name}}'?</h3>
+        <p class="py-4">This action cannot be undone.</p>
+        <div class="modal-action">
+            <button class="btn btn-ghost"
+                    onclick="document.getElementById('modal').innerHTML=''">
+                Cancel
+            </button>
+            <button class="btn btn-error"
+                    hx-delete="{{.DeleteURL}}"
+                    hx-target="{{.Target}}"
+                    hx-swap="outerHTML"
+                    onclick="document.getElementById('modal').innerHTML=''">
+                Delete
+            </button>
+        </div>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button onclick="document.getElementById('modal').innerHTML=''">close</button>
+    </form>
+</dialog>
+{{end}}

--- a/web/templates/partials/link_list.html
+++ b/web/templates/partials/link_list.html
@@ -35,7 +35,10 @@
         <div>
             <h2 class="text-xl font-semibold mb-2">No links yet</h2>
             <p class="text-base-content/60 mb-4">Create your first short link to get started.</p>
-            <a href="/dashboard/links/new" class="btn btn-primary">Create a link</a>
+            <button class="btn btn-primary"
+                    hx-get="/dashboard/links/new"
+                    hx-target="#modal"
+                    hx-swap="innerHTML">Create a link</button>
         </div>
     </div>
 </div>

--- a/web/templates/partials/link_row.html
+++ b/web/templates/partials/link_row.html
@@ -8,16 +8,17 @@
     </td>
     <td class="text-sm text-base-content/60">{{.Description}}</td>
     <td class="text-sm text-base-content/60">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
+    <!-- Governing: SPEC-0013 REQ "Create/Edit Link Form as HTMX Modal", REQ "DaisyUI Delete Confirmation Modal" -->
     <td class="flex gap-1 justify-end">
         <a href="/dashboard/links/{{.ID}}" class="btn btn-xs btn-ghost">View</a>
-        <a href="/dashboard/links/{{.ID}}/edit" class="btn btn-xs btn-ghost">Edit</a>
-        <button
-            class="btn btn-xs btn-error btn-ghost"
-            hx-delete="/dashboard/links/{{.ID}}"
-            hx-target="#link-{{.ID}}"
-            hx-swap="outerHTML"
-            hx-confirm="Delete '{{.Slug}}'?"
-        >Delete</button>
+        <button class="btn btn-xs btn-ghost"
+                hx-get="/dashboard/links/{{.ID}}/edit"
+                hx-target="#modal"
+                hx-swap="innerHTML">Edit</button>
+        <button class="btn btn-xs btn-error btn-ghost"
+                hx-get="/dashboard/links/{{.ID}}/confirm-delete"
+                hx-target="#modal"
+                hx-swap="innerHTML">Delete</button>
     </td>
 </tr>
 {{end}}

--- a/web/templates/partials/modal_form.html
+++ b/web/templates/partials/modal_form.html
@@ -1,0 +1,198 @@
+{{/* Governing: SPEC-0013 REQ "Create/Edit Link Form as HTMX Modal" */}}
+{{define "modal_form"}}
+<dialog id="form-modal" class="modal modal-open">
+    <div class="modal-box">
+        {{block "modal_content" .}}{{end}}
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button onclick="document.getElementById('modal').innerHTML=''">close</button>
+    </form>
+</dialog>
+{{end}}
+
+{{define "new_link_modal"}}
+<dialog id="form-modal" class="modal modal-open">
+    <div class="modal-box max-w-lg">
+        <h3 class="font-bold text-lg mb-4">Create a new link</h3>
+
+        {{if .Error}}
+        <div class="alert alert-error mb-4">
+            <span>{{.Error}}</span>
+        </div>
+        {{end}}
+
+        <form hx-post="/dashboard/links" hx-target="#modal" hx-swap="innerHTML">
+            <div class="form-control mb-4">
+                <label class="label">
+                    <span class="label-text">Slug <span class="text-error">*</span></span>
+                    <span class="label-text-alt text-base-content/50">e.g. jira, standup</span>
+                </label>
+                <label class="input input-bordered flex items-center gap-2">
+                    <span class="text-base-content/50 font-mono">go/</span>
+                    <input
+                        type="text"
+                        name="slug"
+                        class="grow font-mono"
+                        placeholder="my-link"
+                        pattern="[a-z0-9][a-z0-9\-]*[a-z0-9]|[a-z0-9]"
+                        required
+                        value="{{.Form.Slug}}"
+                        hx-get="/dashboard/links/validate-slug"
+                        hx-trigger="input changed delay:300ms"
+                        hx-target="#slug-status"
+                        hx-swap="innerHTML"
+                    >
+                </label>
+                <div id="slug-status" class="mt-1 min-h-[1.25rem]"></div>
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label">
+                    <span class="label-text">Destination URL <span class="text-error">*</span></span>
+                </label>
+                <input
+                    type="url"
+                    name="url"
+                    class="input input-bordered"
+                    placeholder="https://example.com/very/long/url"
+                    required
+                    value="{{.Form.URL}}"
+                >
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label">
+                    <span class="label-text">Title</span>
+                </label>
+                <input
+                    type="text"
+                    name="title"
+                    class="input input-bordered"
+                    placeholder="Short descriptive title"
+                    value="{{.Form.Title}}"
+                >
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label">
+                    <span class="label-text">Description</span>
+                </label>
+                <input
+                    type="text"
+                    name="description"
+                    class="input input-bordered"
+                    placeholder="What does this link go to?"
+                    value="{{.Form.Description}}"
+                >
+            </div>
+
+            <div class="form-control mb-6">
+                <label class="label">
+                    <span class="label-text">Tags</span>
+                    <span class="label-text-alt text-base-content/50">comma-separated</span>
+                </label>
+                <div class="relative">
+                    <input
+                        type="text"
+                        name="tags"
+                        id="tags-input"
+                        class="input input-bordered w-full"
+                        placeholder="engineering, tools, jira"
+                        value="{{.Form.Tags}}"
+                        autocomplete="off"
+                        hx-get="/dashboard/tags/suggest"
+                        hx-trigger="input changed delay:200ms"
+                        hx-target="#tag-suggestions"
+                        hx-swap="innerHTML"
+                        hx-vals='js:{q: event.target.value.split(",").pop().trim()}'
+                        hx-params="none"
+                    >
+                    <ul id="tag-suggestions" class="menu bg-base-100 shadow-lg rounded-box absolute z-10 w-full mt-1"></ul>
+                </div>
+            </div>
+
+            <div class="modal-action">
+                <button type="button" class="btn btn-ghost"
+                        onclick="document.getElementById('modal').innerHTML=''">Cancel</button>
+                <button type="submit" class="btn btn-primary">Create link</button>
+            </div>
+        </form>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button onclick="document.getElementById('modal').innerHTML=''">close</button>
+    </form>
+</dialog>
+
+<script>
+function addTag(name) {
+    var input = document.getElementById('tags-input');
+    var parts = input.value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+    if (parts.length > 0) { parts.pop(); }
+    parts.push(name);
+    input.value = parts.join(', ') + ', ';
+    document.getElementById('tag-suggestions').innerHTML = '';
+    input.focus();
+}
+</script>
+{{end}}
+
+{{define "edit_link_modal"}}
+<dialog id="form-modal" class="modal modal-open">
+    <div class="modal-box max-w-lg">
+        <h3 class="font-bold text-lg mb-4">Edit <span class="font-mono">{{.Link.Slug}}</span></h3>
+
+        {{if .Error}}
+        <div class="alert alert-error mb-4">
+            <span>{{.Error}}</span>
+        </div>
+        {{end}}
+
+        <form hx-put="/dashboard/links/{{.Link.ID}}" hx-target="#modal" hx-swap="innerHTML">
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Slug</span></label>
+                <label class="input input-bordered flex items-center gap-2 opacity-60">
+                    <span class="text-base-content/50 font-mono">go/</span>
+                    <input type="text" class="grow font-mono" disabled value="{{.Link.Slug}}">
+                </label>
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Destination URL <span class="text-error">*</span></span></label>
+                <input type="url" name="url" class="input input-bordered"
+                    required value="{{if .Form.URL}}{{.Form.URL}}{{else}}{{.Link.URL}}{{end}}">
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Title</span></label>
+                <input type="text" name="title" class="input input-bordered"
+                    value="{{if .Form.Title}}{{.Form.Title}}{{else}}{{.Link.Title}}{{end}}">
+            </div>
+
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Description</span></label>
+                <input type="text" name="description" class="input input-bordered"
+                    value="{{if .Form.Description}}{{.Form.Description}}{{else}}{{.Link.Description}}{{end}}">
+            </div>
+
+            <div class="form-control mb-6">
+                <label class="label">
+                    <span class="label-text">Tags</span>
+                    <span class="label-text-alt text-base-content/50">comma-separated</span>
+                </label>
+                <input type="text" name="tags" class="input input-bordered"
+                    placeholder="engineering, tools"
+                    value="{{.Form.Tags}}">
+            </div>
+
+            <div class="modal-action">
+                <button type="button" class="btn btn-ghost"
+                        onclick="document.getElementById('modal').innerHTML=''">Cancel</button>
+                <button type="submit" class="btn btn-primary">Save changes</button>
+            </div>
+        </form>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+        <button onclick="document.getElementById('modal').innerHTML=''">close</button>
+    </form>
+</dialog>
+{{end}}

--- a/web/templates/partials/token_list.html
+++ b/web/templates/partials/token_list.html
@@ -79,11 +79,11 @@
                 </td>
                 <td>
                     {{if not .RevokedAt.Valid}}
+                    <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
                     <button class="btn btn-ghost btn-xs text-error"
-                            hx-delete="/dashboard/settings/tokens/{{.ID}}"
-                            hx-target="#token-content"
-                            hx-swap="innerHTML"
-                            hx-confirm="Revoke this token? Any applications using it will stop working.">Revoke</button>
+                            hx-get="/dashboard/settings/tokens/{{.ID}}/confirm-revoke"
+                            hx-target="#modal"
+                            hx-swap="innerHTML">Revoke</button>
                     {{end}}
                 </td>
             </tr>


### PR DESCRIPTION
## Summary

- Create and edit link forms now render as DaisyUI modal dialogs loaded via HTMX (`hx-get` to `#modal` target), replacing full-page navigation while preserving non-HTMX fallback
- Delete actions across links, keywords, and API tokens now use a styled DaisyUI confirmation modal instead of native `confirm()` — all `hx-confirm` attributes removed
- Dashboard link list auto-refreshes on `linkCreated`/`linkUpdated` HX-Trigger events from successful form submissions
- New partials: `modal_form.html` (new/edit link modal templates), `confirm_delete.html` (reusable delete confirmation modal)
- New routes: `GET .../confirm-delete` for links, keywords, and tokens; `GET /admin/users/{id}/confirm-delete` for future use

## Test plan

- [ ] Click "New link" on dashboard — modal opens with form, slug validation works inside modal
- [ ] Submit new link form — modal closes, link list refreshes automatically
- [ ] Submit with validation error — error displays inside modal, form retains values
- [ ] Click "Edit" on a link row — edit modal opens with pre-filled values
- [ ] Save edit — modal closes, link list refreshes
- [ ] Click "Delete" on a link row — confirmation modal appears with slug name
- [ ] Confirm delete — row removed from table, modal closes
- [ ] Cancel delete (Cancel button or backdrop click) — modal closes, no deletion
- [ ] Click "Delete" on admin keywords page — confirmation modal works
- [ ] Click "Revoke" on API tokens page — confirmation modal works
- [ ] Visit `/dashboard/links/new` directly (non-HTMX) — full page renders normally
- [ ] Verify no `hx-confirm` attributes remain in `web/templates/`

Closes #80
Part of #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)