### PR TITLE
Add admin links screen with inline editing and deletion

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -36,9 +36,11 @@ type AdminUsersPage struct {
 }
 
 // AdminLinksPage is the template data for the admin link list.
+// Governing: SPEC-0011 REQ "Admin Links Screen"
 type AdminLinksPage struct {
 	BasePage
-	Links []*store.Link
+	Links []*store.AdminLink
+	Query string
 }
 
 // Dashboard renders the admin overview with summary stats.
@@ -92,15 +94,104 @@ func (h *AdminHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 }
 
 // Links renders the admin link list (all links across all users).
-// Governing: SPEC-0004 REQ "Admin Dashboard"
+// Supports HTMX search via ?q= query parameter with debounce.
+// Governing: SPEC-0011 REQ "Admin Links Screen", ADR-0007
 func (h *AdminHandler) Links(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
-	allLinks, _ := h.links.ListAll(r.Context())
+	q := r.URL.Query().Get("q")
+	allLinks, _ := h.links.ListAllAdmin(r.Context(), q)
 	data := AdminLinksPage{
 		BasePage: newBasePage(r, user),
 		Links:    allLinks,
+		Query:    q,
+	}
+	if isHTMX(r) {
+		renderPageFragment(w, "admin/links.html", "admin_link_list", data)
+		return
 	}
 	render(w, "admin/links.html", data)
+}
+
+// EditLinkRow returns an editable <tr> fragment for inline link editing.
+// Governing: SPEC-0011 REQ "Admin Inline Link Editing", ADR-0007
+func (h *AdminHandler) EditLinkRow(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetAdminLink(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	renderPageFragment(w, "admin/links.html", "admin_link_edit_row", link)
+}
+
+// UpdateLink handles PUT /admin/links/{id} — updates url, title, description and returns the read-only row.
+// Governing: SPEC-0011 REQ "Admin Link Deletion Endpoint", ADR-0005
+func (h *AdminHandler) UpdateLink(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	url := r.FormValue("url")
+	title := r.FormValue("title")
+	description := r.FormValue("description")
+
+	_, err := h.links.Update(r.Context(), id, url, title, description)
+	if err != nil {
+		http.Error(w, "update failed", http.StatusInternalServerError)
+		return
+	}
+
+	link, err := h.links.GetAdminLink(r.Context(), id)
+	if err != nil {
+		http.Error(w, "fetch failed", http.StatusInternalServerError)
+		return
+	}
+	renderPageFragment(w, "admin/links.html", "admin_link_row", link)
+}
+
+// DeleteLink handles DELETE /admin/links/{id} — removes the link and returns an OOB toast.
+// Governing: SPEC-0011 REQ "Admin Link Deletion Endpoint", ADR-0005
+func (h *AdminHandler) DeleteLink(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := h.links.Delete(r.Context(), id); err != nil {
+		http.Error(w, "delete failed", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`<div id="toast-area" hx-swap-oob="innerHTML:#toast-area"><div class="alert alert-success"><span>Link deleted.</span></div></div>`))
+}
+
+// LinkRow returns the read-only <tr> fragment for a single admin link row.
+// Used by the Cancel button during inline editing to restore the original row.
+// Governing: SPEC-0011 REQ "Admin Inline Link Editing"
+func (h *AdminHandler) LinkRow(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetAdminLink(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	renderPageFragment(w, "admin/links.html", "admin_link_row", link)
+}
+
+// ConfirmDeleteLink renders the delete confirmation modal for a link.
+// Governing: SPEC-0011 REQ "Admin Link Deletion", SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
+func (h *AdminHandler) ConfirmDeleteLink(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	data := ConfirmDeleteData{
+		Name:      link.Slug,
+		DeleteURL: "/admin/links/" + id,
+		Target:    "#admin-link-" + id,
+	}
+	renderFragment(w, "confirm_delete", data)
 }
 
 // ConfirmDeleteUser renders the delete confirmation modal for a user.

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -118,7 +118,13 @@ func NewRouter(deps Deps) http.Handler {
 		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
 		r.Get("/admin/users/{id}/confirm-delete", admin.ConfirmDeleteUser)
 		r.Put("/admin/users/{id}/role", admin.UpdateRole)
+		// Governing: SPEC-0011 REQ "Admin Links Screen", "Admin Inline Link Editing", "Admin Link Deletion"
 		r.Get("/admin/links", admin.Links)
+		r.Get("/admin/links/{id}/edit", admin.EditLinkRow)
+		r.Get("/admin/links/{id}/row", admin.LinkRow)
+		r.Put("/admin/links/{id}", admin.UpdateLink)
+		r.Get("/admin/links/{id}/confirm-delete", admin.ConfirmDeleteLink)
+		r.Delete("/admin/links/{id}", admin.DeleteLink)
 
 		// Governing: SPEC-0008 REQ "Keyword Host Discovery", ADR-0011
 		r.Get("/admin/keywords", keywordsHandler.Index)

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -70,6 +70,14 @@
                     </svg>
                     Users
                 </a>
+                <!-- Governing: SPEC-0011 REQ "Admin Links Screen" -->
+                <a href="/admin/links" data-nav="/admin/links"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium hover:bg-base-300 transition-colors">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                    Links
+                </a>
             </details>
             {{end}}
         </nav>

--- a/web/templates/pages/admin/links.html
+++ b/web/templates/pages/admin/links.html
@@ -3,43 +3,119 @@
 {{define "title"}}All Links — Admin — Joe Links{{end}}
 
 {{define "content"}}
-<!-- Governing: SPEC-0004 REQ "Admin Dashboard" -->
+<!-- Governing: SPEC-0011 REQ "Admin Links Screen", ADR-0007 -->
 <div class="flex items-center justify-between mb-6">
     <h1 class="text-2xl font-bold">All Links</h1>
     <div class="flex items-center gap-3">
         <span class="text-base-content/60 text-sm">{{len .Links}} total</span>
-        <a href="/admin" class="btn btn-ghost btn-sm">← Admin</a>
+        <a href="/admin" class="btn btn-ghost btn-sm">&larr; Admin</a>
     </div>
 </div>
 
+<!-- Governing: SPEC-0011 REQ "Admin Links Screen" — HTMX search with debounce -->
+<div class="mb-4">
+    <input type="text" name="q" placeholder="Search by slug, URL, title, or owner..."
+           class="input input-bordered w-full max-w-md"
+           value="{{.Query}}"
+           hx-get="/admin/links"
+           hx-trigger="keyup changed delay:300ms"
+           hx-target="#admin-link-list"
+           hx-swap="innerHTML" />
+</div>
+
+<div id="admin-link-list">
+    {{template "admin_link_list" .}}
+</div>
+{{end}}
+
+{{define "admin_link_list"}}
 {{if .Links}}
 <div class="overflow-x-auto">
     <table class="table table-sm">
         <thead>
             <tr>
                 <th>Slug</th>
-                <th>Destination</th>
-                <th>Description</th>
+                <th>URL</th>
+                <th>Title</th>
+                <th>Owner(s)</th>
+                <th>Tags</th>
                 <th>Created</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
             {{range .Links}}
-            <tr>
-                <td>
-                    <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
-                </td>
-                <td class="max-w-xs truncate text-sm">
-                    <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
-                </td>
-                <td class="text-sm text-base-content/70">{{.Description}}</td>
-                <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
-            </tr>
+            {{template "admin_link_row" .}}
             {{end}}
         </tbody>
     </table>
 </div>
 {{else}}
-<p class="text-base-content/60 py-8 text-center">No links yet.</p>
+<p class="text-base-content/60 py-8 text-center">No links found.</p>
 {{end}}
+{{end}}
+
+{{define "admin_link_row"}}
+<!-- Governing: SPEC-0011 REQ "Admin Links Screen" — read-only row with edit/delete actions -->
+<tr id="admin-link-{{.ID}}">
+    <td>
+        <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
+    </td>
+    <td class="max-w-xs truncate text-sm">
+        <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
+    </td>
+    <td class="text-sm text-base-content/70">{{.Title}}</td>
+    <td class="text-sm text-base-content/70">{{.Owners}}</td>
+    <td class="text-sm">
+        {{range .TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}
+    </td>
+    <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
+    <td class="flex gap-1 justify-end">
+        <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" -->
+        <button class="btn btn-xs btn-ghost"
+                hx-get="/admin/links/{{.ID}}/edit"
+                hx-target="#admin-link-{{.ID}}"
+                hx-swap="outerHTML">Edit</button>
+        <!-- Governing: SPEC-0011 REQ "Admin Link Deletion", SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
+        <button class="btn btn-xs btn-error btn-ghost"
+                hx-get="/admin/links/{{.ID}}/confirm-delete"
+                hx-target="#modal"
+                hx-swap="innerHTML">Delete</button>
+    </td>
+</tr>
+{{end}}
+
+{{define "admin_link_edit_row"}}
+<!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — inline edit form replacing read-only row -->
+<tr id="admin-link-{{.ID}}">
+    <td>
+        <span class="font-mono font-semibold text-base-content/50">{{.Slug}}</span>
+    </td>
+    <td>
+        <input type="text" name="url" value="{{.URL}}" form="edit-link-{{.ID}}"
+               class="input input-bordered input-xs w-full" required />
+    </td>
+    <td>
+        <input type="text" name="title" value="{{.Title}}" form="edit-link-{{.ID}}"
+               class="input input-bordered input-xs w-full" />
+    </td>
+    <td class="text-sm text-base-content/70">{{.Owners}}</td>
+    <td colspan="2">
+        <input type="text" name="description" value="{{.Description}}" form="edit-link-{{.ID}}"
+               class="input input-bordered input-xs w-full" placeholder="Description" />
+    </td>
+    <td class="flex gap-1 justify-end">
+        <form id="edit-link-{{.ID}}"
+              hx-put="/admin/links/{{.ID}}"
+              hx-target="#admin-link-{{.ID}}"
+              hx-swap="outerHTML">
+            <button type="submit" class="btn btn-xs btn-primary">Save</button>
+        </form>
+        <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — cancel restores original row -->
+        <button class="btn btn-xs btn-ghost"
+                hx-get="/admin/links/{{.ID}}/row"
+                hx-target="#admin-link-{{.ID}}"
+                hx-swap="outerHTML">Cancel</button>
+    </td>
+</tr>
 {{end}}


### PR DESCRIPTION
## Summary
- Add full admin links management at `GET /admin/links` with HTMX debounced search, inline row editing, and DaisyUI delete confirmation modal
- Add `ListAllAdmin` and `GetAdminLink` store methods that join owner display names and tag names via `GROUP_CONCAT`
- Add `PUT /admin/links/{id}` and `DELETE /admin/links/{id}` endpoints for admin link updates and deletion
- Add "Links" entry to the admin sidebar navigation

## Changes
- **`internal/store/link_store.go`**: Add `AdminLink` struct (with `TagList()` method), `ListAllAdmin(ctx, q)` with search support, and `GetAdminLink(ctx, id)` for single-link admin view
- **`internal/handler/admin.go`**: Enhance `Links` handler with search + HTMX partial; add `EditLinkRow`, `UpdateLink`, `DeleteLink`, `LinkRow`, `ConfirmDeleteLink` handlers
- **`internal/handler/router.go`**: Register admin link CRUD routes (`/admin/links/{id}/edit`, `/admin/links/{id}/row`, `PUT /admin/links/{id}`, `DELETE /admin/links/{id}`, `/admin/links/{id}/confirm-delete`)
- **`web/templates/pages/admin/links.html`**: Full rewrite with search input, `admin_link_list`/`admin_link_row`/`admin_link_edit_row` named templates for HTMX row swapping
- **`web/templates/base.html`**: Add "Links" nav item under admin sidebar section

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 56 tests)
- [ ] Visit `/admin/links` as admin — all links listed with owner names, tag chips, actions
- [ ] Type in search box — list updates after 300ms debounce
- [ ] Click Edit — row becomes inline form with read-only slug, editable URL/title/description
- [ ] Click Save — PUT updates link, row re-renders read-only
- [ ] Click Cancel — original row restored
- [ ] Click Delete — DaisyUI modal appears, confirm removes row + shows toast
- [ ] Visit `/admin/links` as non-admin — 403 Forbidden

Closes #82
Part of #81
Governing: SPEC-0011, ADR-0007, ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)