### PR TITLE
Add visibility column, link_shares table, and store methods (SPEC-0010 data layer)

### DIFF
--- a/internal/db/migrations/00009_add_link_visibility.sql
+++ b/internal/db/migrations/00009_add_link_visibility.sql
@@ -1,0 +1,6 @@
+-- Governing: SPEC-0010 REQ "Visibility Column on Links Table"
+-- +goose Up
+ALTER TABLE links ADD COLUMN visibility TEXT NOT NULL DEFAULT 'public';
+
+-- +goose Down
+ALTER TABLE links DROP COLUMN visibility;

--- a/internal/db/migrations/00010_create_link_shares.sql
+++ b/internal/db/migrations/00010_create_link_shares.sql
@@ -1,0 +1,15 @@
+-- Governing: SPEC-0010 REQ "Link Shares Table"
+-- +goose Up
+CREATE TABLE IF NOT EXISTS link_shares (
+    link_id    TEXT NOT NULL REFERENCES links(id) ON DELETE CASCADE,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    shared_by  TEXT NOT NULL REFERENCES users(id),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (link_id, user_id)
+);
+
+CREATE INDEX idx_link_shares_link_user ON link_shares(link_id, user_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_link_shares_link_user;
+DROP TABLE IF EXISTS link_shares;

--- a/internal/store/validate.go
+++ b/internal/store/validate.go
@@ -21,6 +21,10 @@ var (
 	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
 	ErrDuplicateVariable = errors.New("duplicate variable name in URL template")
 
+	// ErrInvalidVisibility is returned when a visibility value is not one of public, private, secure.
+	// Governing: SPEC-0010 REQ "Visibility Column on Links Table"
+	ErrInvalidVisibility = errors.New("visibility must be one of: public, private, secure")
+
 	slugRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`)
 
 	// VarPlaceholderRe matches $varname placeholders in URL templates.
@@ -64,4 +68,15 @@ func ValidateURLVariables(url string) error {
 		seen[v] = true
 	}
 	return nil
+}
+
+// ValidateVisibility checks that v is one of the allowed visibility values.
+// Governing: SPEC-0010 REQ "Visibility Column on Links Table"
+func ValidateVisibility(v string) error {
+	switch v {
+	case "public", "private", "secure":
+		return nil
+	default:
+		return ErrInvalidVisibility
+	}
 }


### PR DESCRIPTION
## Summary

- Adds goose migration `00009_add_link_visibility.sql`: `ALTER TABLE links ADD COLUMN visibility TEXT NOT NULL DEFAULT 'public'`
- Adds goose migration `00010_create_link_shares.sql`: creates `link_shares` table with composite PK `(link_id, user_id)` and index
- Adds `Visibility` field to `Link` struct and `ShareRecord` struct
- Adds `HasShare`, `AddShare`, `RemoveShare`, `ListShares` methods to `LinkStore`
- Adds `ValidateVisibility` function and `ErrInvalidVisibility` sentinel error
- Updates `Create` INSERT to include `visibility` column (default `'public'`)

Closes #91 / Part of #90

Governing: SPEC-0010 REQ "Visibility Column on Links Table", REQ "Link Shares Table", REQ "Database Migration"

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes all existing tests (no regressions)
- [ ] Verify migration 00009 adds visibility column with default 'public'
- [ ] Verify migration 00010 creates link_shares table with correct schema
- [ ] Verify ValidateVisibility accepts public/private/secure, rejects others

🤖 Generated with [Claude Code](https://claude.com/claude-code)