### PR TITLE
docs: SPEC-0014 Link List UI Consistency

### DIFF
--- a/docs/openspec/specs/link-list-consistency/design.md
+++ b/docs/openspec/specs/link-list-consistency/design.md
@@ -1,0 +1,217 @@
+# Design: Link List UI Consistency
+
+## Context
+
+The joe-links UI currently has two separate link table implementations: the dashboard view in `web/templates/partials/link_list.html` and the admin view inline in `web/templates/pages/admin/links.html`. These diverged over time as columns were added to the admin view (Title, Owner, Tags) that the dashboard view does not need. This creates a maintenance burden — changes to row layout, action buttons, or styling must be duplicated. Additionally, several small UX issues have accumulated: a redundant View button in the actions column (the slug is already a link), the copy button buried in the actions column instead of near the slug it copies, a missing Keywords link in the admin sidebar, and an inconsistent text-based delete button on the Keywords page.
+
+See SPEC-0004 (Application Views and Routing), SPEC-0011 (Admin Management), SPEC-0013 (UI/UX Improvements).
+
+## Goals / Non-Goals
+
+### Goals
+- Consolidate two link table templates into one configurable shared partial
+- Display `keyword/slug` format with visually distinct keyword prefix
+- Move the copy button inline with the slug for better discoverability
+- Remove the redundant View (eye) button from actions
+- Add the missing Keywords link to the admin sidebar
+- Convert the Keywords delete button to an icon button for visual consistency
+
+### Non-Goals
+- Changing the link data model or adding new database columns
+- Modifying the admin inline-edit row template (`admin_link_edit_row`) — it has different layout needs and remains separate
+- Adding pagination or infinite scroll to the link list (separate concern)
+- Changing the link list HTMX partial swap behavior
+- Responsive/mobile layout changes
+
+## Decisions
+
+### Shared Partial with Column Flags Over Template Inheritance
+
+**Choice**: Use a single `link_list` partial that accepts boolean flags (e.g., `ShowTitle`, `ShowOwner`, `ShowTags`) in the template data to conditionally render columns. The calling template passes these flags as fields in the page data struct.
+
+**Rationale**: Go's `html/template` does not support template inheritance or parameterized template calls in the way that Jinja2 or Blade do. The simplest approach is boolean flags on the data struct. This avoids introducing a new abstraction (like a column descriptor slice) that would be over-engineered for the two known column sets. If a third view is added later, the flags pattern extends naturally.
+
+**Alternative considered**: A `Columns []string` slice that the template iterates over — rejected because Go templates lack the ability to dynamically look up struct fields by string name without reflection helpers, which would add complexity for no clear benefit.
+
+### Keyword Prefix Styling with Nested Spans
+
+**Choice**: Render the slug cell as `<a href="/{slug}"><span class="text-base-content/50">{keyword}/</span>{slug}</a>` — the keyword prefix uses a muted color class while the slug portion inherits the link's primary color.
+
+**Rationale**: This keeps the entire text as a single clickable link while visually distinguishing the keyword prefix. The muted class (`text-base-content/50`) is already used throughout the codebase for secondary text. No JavaScript is needed.
+
+### Copy Button Inline with Slug
+
+**Choice**: Place the copy button inside the slug `<td>` cell, immediately after the link element, using a `flex items-center gap-1` wrapper. Remove the copy button from the actions `<td>`.
+
+**Rationale**: The copy button's purpose is tightly coupled to the slug text. Placing it inline makes the relationship obvious and reduces visual clutter in the actions column. The `gap-1` spacing keeps it visually attached to the slug without overlapping.
+
+### Admin Edit Row Stays Separate
+
+**Choice**: The `admin_link_edit_row` template remains a standalone define, not merged into the shared partial.
+
+**Rationale**: The inline edit row has a fundamentally different layout (input fields, Save/Cancel buttons, different column spans). Trying to make the shared partial handle both read and edit modes would significantly increase template complexity for no reuse benefit — only the admin view uses inline editing.
+
+## Architecture
+
+### Template Data Flow
+
+```mermaid
+graph TD
+    subgraph Handler["Go Handler"]
+        DashHandler["Dashboard handler"]
+        AdminHandler["Admin links handler"]
+    end
+
+    subgraph Data["Page Data Struct"]
+        DashData["LinkListPage{<br/>ShowTitle: false<br/>ShowOwner: false<br/>ShowTags: false<br/>Keyword: 'go'}"]
+        AdminData["LinkListPage{<br/>ShowTitle: true<br/>ShowOwner: true<br/>ShowTags: true<br/>Keyword: ''}"]
+    end
+
+    subgraph Template["Shared Partial"]
+        LinkList["link_list partial<br/>conditionally renders columns<br/>based on Show* flags"]
+    end
+
+    DashHandler --> DashData
+    AdminHandler --> AdminData
+    DashData --> LinkList
+    AdminData --> LinkList
+```
+
+### Slug Cell Layout
+
+```
++--------------------------------------------------+
+| go/my-slug  [copy icon]                          |
+| ^muted      ^primary    ^btn-ghost btn-xs        |
++--------------------------------------------------+
+```
+
+### Sidebar Admin Section (Updated)
+
+```
+Admin (details/summary)
+  +-- Overview    /admin
+  +-- Users       /admin/users
+  +-- Links       /admin/links
+  +-- Keywords    /admin/keywords    <-- NEW
+```
+
+## Template Changes
+
+### Shared Link List Partial (`web/templates/partials/link_list.html`)
+
+The partial checks `Show*` flags to conditionally render `<th>` and `<td>` elements:
+
+```html
+{{define "link_list"}}
+{{if .Links}}
+<div class="overflow-x-auto">
+    <table class="table table-zebra w-full">
+        <thead>
+            <tr>
+                <th>Slug</th>
+                <th>URL</th>
+                {{if .ShowTitle}}<th>Title</th>{{end}}
+                {{if .ShowOwner}}<th>Owner(s)</th>{{end}}
+                {{if .ShowTags}}<th>Tags</th>{{end}}
+                <th>{{if .ShowTitle}}{{else}}Description{{end}}</th>
+                <th>Created</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody id="links-table">
+            {{range .Links}}
+            <tr id="link-{{.ID}}">
+                <td>
+                    <div class="flex items-center gap-1">
+                        <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">
+                            {{if $.Keyword}}<span class="text-base-content/50">{{$.Keyword}}/</span>{{end}}{{.Slug}}
+                        </a>
+                        <!-- inline copy button -->
+                        ...
+                    </div>
+                </td>
+                ...
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{end}}
+{{end}}
+```
+
+### Admin Links Page (`web/templates/pages/admin/links.html`)
+
+Replaces inline `admin_link_list` with a call to the shared partial:
+
+```html
+<div id="admin-link-list">
+    {{template "link_list" .}}
+</div>
+```
+
+The `admin_link_edit_row` and `admin_link_row` templates remain for inline editing support.
+
+### Keywords Delete Button
+
+```html
+<!-- Before -->
+<button class="btn btn-ghost btn-xs text-error" ...>Delete</button>
+
+<!-- After -->
+<button class="btn btn-xs btn-ghost text-error tooltip tooltip-left" data-tip="Delete" ...>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24"
+         stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+    </svg>
+</button>
+```
+
+### Admin Sidebar Keywords Link (base.html)
+
+```html
+<a href="/admin/keywords" data-nav="/admin/keywords"
+   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium hover:bg-base-300 transition-colors">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none"
+         viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+    </svg>
+    Keywords
+</a>
+```
+
+## Go Handler Changes
+
+The page data struct used by both dashboard and admin link list handlers needs the column flag fields:
+
+```go
+type LinkListData struct {
+    BasePage
+    Links     []LinkView
+    Keyword   string
+    Query     string
+    Tag       string
+    ShowTitle bool
+    ShowOwner bool
+    ShowTags  bool
+}
+```
+
+The dashboard handler sets `ShowTitle: false, ShowOwner: false, ShowTags: false`.
+The admin handler sets `ShowTitle: true, ShowOwner: true, ShowTags: true`.
+
+## Risks / Trade-offs
+
+- **Shared partial complexity**: Adding conditional columns makes the template slightly harder to read than two separate purpose-built templates. However, the maintenance benefit of a single source of truth for link row rendering outweighs this. The two-template approach has already led to divergent styling.
+
+- **Admin inline edit stays separate**: The `admin_link_edit_row` template cannot use the shared partial because it replaces cells with input fields. This means the admin view still has some template duplication between the read row and the edit row, but this is inherent to the inline-editing pattern.
+
+- **Keyword prefix display depends on handler passing `Keyword`**: The dashboard handler already passes this (from the configured keyword). The admin handler may need to be updated to also pass the keyword if the admin view should show keyword-prefixed slugs.
+
+## Open Questions
+
+- Should the admin link list also show keyword-prefixed slugs, or only the dashboard view? The admin might prefer bare slugs since they manage all links across keywords.
+- Should the Description column be shown in admin view alongside Title, or should Title replace Description? Currently the dashboard shows Description and admin shows Title — the shared partial needs a clear rule for which to display.

--- a/docs/openspec/specs/link-list-consistency/spec.md
+++ b/docs/openspec/specs/link-list-consistency/spec.md
@@ -1,0 +1,112 @@
+# SPEC-0014: Link List UI Consistency
+
+## Overview
+
+This specification defines UI consistency improvements for the link list views and admin navigation in the joe-links web application: abstracting the two divergent link table implementations into a single shared partial template, polishing the slug display and copy affordance, removing redundant action buttons, adding the missing Keywords sidebar link, and converting the Keywords delete button to an icon button matching the rest of the admin UI.
+
+See SPEC-0004 (Application Views and Routing), SPEC-0011 (Admin Management), SPEC-0013 (UI/UX Improvements), ADR-0007 (Application Views and Routing).
+
+---
+
+## Requirements
+
+### Requirement: Unified Link List Partial
+
+The dashboard link list (`web/templates/partials/link_list.html`) and the admin link list (inline `admin_link_list`/`admin_link_row` in `web/templates/pages/admin/links.html`) MUST be consolidated into a single shared partial template. The partial MUST accept configuration from the caller to control which columns are displayed. At minimum the following column sets MUST be supported:
+
+- **Dashboard view**: Slug, URL, Description, Created, Actions (edit, delete)
+- **Admin view**: Slug, URL, Title, Owner(s), Tags, Created, Actions (edit, delete)
+
+The partial MUST NOT hard-code either column set; the caller MUST control visibility via template data (e.g., a `Columns` field or boolean flags like `ShowOwner`, `ShowTags`, `ShowTitle`).
+
+#### Scenario: Dashboard Renders Shared Partial
+
+- **WHEN** an authenticated user visits `/dashboard`
+- **THEN** the link list MUST render using the shared `link_list` partial with Slug, URL, Description, Created, and Actions columns visible
+- **AND** the Owner(s), Tags, and Title columns MUST NOT be visible
+
+#### Scenario: Admin Renders Shared Partial
+
+- **WHEN** an admin user visits `/admin/links`
+- **THEN** the link list MUST render using the same shared `link_list` partial with Slug, URL, Title, Owner(s), Tags, Created, and Actions columns visible
+
+#### Scenario: Empty State Preserved
+
+- **WHEN** the link list has no results
+- **THEN** the empty state message MUST still render appropriately for both dashboard and admin contexts
+
+---
+
+### Requirement: Slug Display with Keyword Prefix
+
+The slug column in the link list MUST display the full `keyword/slug` path (e.g., `go/slack`) when a keyword is configured. The keyword portion MUST be visually distinct from the slug portion — rendered in a muted/secondary style (e.g., `text-base-content/50`) while the slug portion remains primary-styled. When no keyword is configured, the slug MUST display without a prefix.
+
+#### Scenario: Slug with Keyword Prefix
+
+- **WHEN** a link list row is rendered and a keyword is configured for the view
+- **THEN** the slug cell MUST display `{keyword}/{slug}` where `{keyword}` is visually muted and `{slug}` is styled as a primary link
+- **AND** the entire text MUST be a clickable link that opens the short URL in a new tab
+
+#### Scenario: Slug without Keyword
+
+- **WHEN** a link list row is rendered and no keyword is configured
+- **THEN** the slug cell MUST display only the slug as a primary-styled link (current behavior)
+
+---
+
+### Requirement: Inline Copy Button
+
+The copy-to-clipboard button MUST be repositioned from the actions column to appear inline immediately to the right of the slug text in the slug column. The button MUST copy the full slug path (including keyword prefix if present) to the clipboard. The button MUST show a "Copied!" tooltip feedback on successful copy.
+
+#### Scenario: Copy Button Position
+
+- **WHEN** a link list row is rendered
+- **THEN** a small clipboard icon button MUST appear inline immediately after the slug text, within the slug column cell
+- **AND** the copy button MUST NOT appear in the actions column
+
+#### Scenario: Copy Includes Keyword Prefix
+
+- **WHEN** a user clicks the copy button and a keyword is configured
+- **THEN** the clipboard MUST contain `{keyword}/{slug}` (e.g., `go/slack`)
+
+---
+
+### Requirement: Remove View Button
+
+The "View" (eye icon) button MUST be removed from the actions column of link list rows. The slug text itself already serves as a clickable link that opens the destination URL in a new tab, making the separate View button redundant.
+
+#### Scenario: No View Button in Actions
+
+- **WHEN** a link list row is rendered (dashboard or admin)
+- **THEN** the actions column MUST NOT contain a "View" or eye-icon button
+- **AND** the slug text MUST remain a clickable link opening the short URL in a new tab
+
+---
+
+### Requirement: Keywords Admin Sidebar Link
+
+The admin sidebar section in `web/templates/base.html` MUST include a "Keywords" navigation link pointing to `/admin/keywords`. The link MUST appear within the `<details>` admin section alongside the existing Overview, Users, and Links items. The link MUST use the `data-nav="/admin/keywords"` attribute for active state highlighting.
+
+#### Scenario: Keywords Link Visible to Admins
+
+- **WHEN** an admin user views the sidebar and the admin section is expanded
+- **THEN** a "Keywords" link MUST be visible within the admin section, pointing to `/admin/keywords`
+
+#### Scenario: Keywords Active State
+
+- **WHEN** an admin user navigates to `/admin/keywords`
+- **THEN** the Keywords sidebar link MUST show the active navigation highlight
+- **AND** the admin `<details>` section MUST be open (since `/admin/keywords` is an admin page)
+
+---
+
+### Requirement: Keywords Delete Icon Button
+
+The delete button on keyword rows in `web/templates/pages/admin/keywords.html` MUST be changed from a text "Delete" button to a trash icon button, matching the icon button pattern used in link list rows and other admin tables. The button MUST use the same trash SVG icon, `btn-xs btn-ghost text-error` classes, and tooltip pattern used elsewhere.
+
+#### Scenario: Keyword Delete Button Style
+
+- **WHEN** a keyword row is rendered in `/admin/keywords`
+- **THEN** the delete button MUST display a trash icon (not text "Delete")
+- **AND** the button MUST have a tooltip reading "Delete"
+- **AND** the button MUST use `btn-xs btn-ghost text-error` styling consistent with link list delete buttons


### PR DESCRIPTION
## Summary

- Adds SPEC-0014 (Link List UI Consistency) specification and design documents
- Defines requirements for abstracting the link list widget, slug/copy polish, keywords sidebar link, and icon button consistency

## Artifacts

- `docs/openspec/specs/link-list-consistency/spec.md` -- 6 requirements with scenarios
- `docs/openspec/specs/link-list-consistency/design.md` -- architecture decisions, template changes, data flow

## Related Issues

- #105: Abstract link list widget, slug/copy polish
- #106: Keywords admin sidebar link and icon buttons

## Test plan

- [ ] Spec reviewed for RFC 2119 language correctness
- [ ] Design reviewed for consistency with existing patterns (SPEC-0013, ADR-0007)

🤖 Generated with [Claude Code](https://claude.com/claude-code)