### PR TITLE
feat: add keywords sidebar link and icon delete button (#106)

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -78,6 +78,14 @@
                     </svg>
                     Links
                 </a>
+                <!-- Governing: SPEC-0014 -->
+                <a href="/admin/keywords" data-nav="/admin/keywords"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium hover:bg-base-300 transition-colors">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+                    </svg>
+                    Keywords
+                </a>
             </details>
             {{end}}
         </nav>

--- a/web/templates/pages/admin/keywords.html
+++ b/web/templates/pages/admin/keywords.html
@@ -49,11 +49,16 @@
         <td class="text-sm font-mono">{{.URLTemplate}}</td>
         <td class="text-sm text-base-content/70">{{.Description}}</td>
         <td>
-            <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
-            <button class="btn btn-ghost btn-xs text-error"
+            <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal", SPEC-0014 -->
+            <button class="btn btn-xs btn-ghost text-error tooltip tooltip-left"
+                    data-tip="Delete"
                     hx-get="/admin/keywords/{{.ID}}/confirm-delete"
                     hx-target="#modal"
-                    hx-swap="innerHTML">Delete</button>
+                    hx-swap="innerHTML">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+            </button>
         </td>
     </tr>
     {{else}}


### PR DESCRIPTION
## Summary
- Add **Keywords** nav link to admin sidebar `<details>` section with hash/hashtag SVG icon
- Convert delete button in `keywords.html` from text "Delete" to trash icon button with tooltip
- Governing: SPEC-0014

Closes #106

## Test plan
- [ ] Verify Keywords link appears in admin sidebar between Links and the bottom of the details section
- [ ] Verify active state highlighting works on `/admin/keywords`
- [ ] Verify delete button shows trash icon with tooltip on hover
- [ ] Verify delete confirmation modal still triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)