### PR TITLE
Enforce visibility in slug resolver, add shared-with-me dashboard filter, admin visibility badges (SPEC-0010)

### DIFF
--- a/internal/handler/resolve_test.go
+++ b/internal/handler/resolve_test.go
@@ -34,7 +34,7 @@ func newResolveTestEnv(t *testing.T) *resolveTestEnv {
 		t.Fatalf("seed user: %v", err)
 	}
 
-	rh := NewResolveHandler(ls, ks)
+	rh := NewResolveHandler(ls, ks, owns)
 	return &resolveTestEnv{ls: ls, ks: ks, rh: rh, userID: u.ID}
 }
 

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -161,7 +161,8 @@ func NewRouter(deps Deps) http.Handler {
 	// Uses OptionalUser so the 404 page can offer "Create this link" when logged in.
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — catch-all AFTER named routes
 	// Governing: SPEC-0009 REQ "Multi-Segment Path Resolution", ADR-0013 — wildcard for multi-segment paths
-	resolver := NewResolveHandler(deps.LinkStore, deps.KeywordStore)
+	// Governing: SPEC-0010 REQ "Secure Link Resolution" — resolver needs OwnershipStore for access checks
+	resolver := NewResolveHandler(deps.LinkStore, deps.KeywordStore, deps.OwnershipStore)
 	r.With(deps.AuthMiddleware.OptionalUser).Get("/{slug}*", resolver.Resolve)
 
 	return r

--- a/web/templates/pages/403.html
+++ b/web/templates/pages/403.html
@@ -1,0 +1,19 @@
+{{template "base" .}}
+
+{{define "title"}}Forbidden — Joe Links{{end}}
+
+{{define "content"}}
+<!-- Governing: SPEC-0010 REQ "Secure Link Resolution" -->
+<div class="hero py-24">
+    <div class="hero-content text-center">
+        <div>
+            <h1 class="text-5xl font-bold mb-4">403</h1>
+            <h2 class="text-2xl font-semibold mb-2">Access denied</h2>
+            <p class="text-base-content/60 mb-6">
+                You don't have permission to access this link.
+            </p>
+            <a href="/dashboard" class="btn btn-primary">Go to dashboard</a>
+        </div>
+    </div>
+</div>
+{{end}}

--- a/web/templates/pages/admin/links.html
+++ b/web/templates/pages/admin/links.html
@@ -36,6 +36,7 @@
 
 {{define "admin_link_row"}}
 <!-- Governing: SPEC-0011 REQ "Admin Links Screen" — read-only row with edit/delete actions -->
+<!-- Governing: SPEC-0010 REQ "Admin Visibility Override" — visibility badge -->
 <tr id="admin-link-{{.ID}}">
     <td>
         <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
@@ -47,6 +48,9 @@
     <td class="text-sm text-base-content/70">{{.Owners}}</td>
     <td class="text-sm">
         {{range .TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}
+    </td>
+    <td class="text-sm">
+        <span class="badge badge-sm {{if eq .Visibility "secure"}}badge-error{{else if eq .Visibility "private"}}badge-warning{{else}}badge-ghost{{end}}">{{.Visibility}}</span>
     </td>
     <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
     <td class="flex gap-1 justify-end">
@@ -66,6 +70,7 @@
 
 {{define "admin_link_edit_row"}}
 <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — inline edit form replacing read-only row -->
+<!-- Governing: SPEC-0010 REQ "Admin Visibility Override" — visibility selector in edit form -->
 <tr id="admin-link-{{.ID}}">
     <td>
         <span class="font-mono font-semibold text-base-content/50">{{.Slug}}</span>
@@ -79,10 +84,18 @@
                class="input input-bordered input-xs w-full" />
     </td>
     <td class="text-sm text-base-content/70">{{.Owners}}</td>
-    <td colspan="2">
+    <td>
         <input type="text" name="description" value="{{.Description}}" form="edit-link-{{.ID}}"
                class="input input-bordered input-xs w-full" placeholder="Description" />
     </td>
+    <td>
+        <select name="visibility" form="edit-link-{{.ID}}" class="select select-bordered select-xs w-full">
+            <option value="public" {{if eq .Visibility "public"}}selected{{end}}>public</option>
+            <option value="private" {{if eq .Visibility "private"}}selected{{end}}>private</option>
+            <option value="secure" {{if eq .Visibility "secure"}}selected{{end}}>secure</option>
+        </select>
+    </td>
+    <td></td>
     <td class="flex gap-1 justify-end">
         <form id="edit-link-{{.ID}}"
               hx-put="/admin/links/{{.ID}}"

--- a/web/templates/pages/dashboard.html
+++ b/web/templates/pages/dashboard.html
@@ -28,6 +28,18 @@
     >
 </div>
 
+<!-- Governing: SPEC-0010 REQ "Dashboard Visibility Filtering" — My Links / Shared with me tabs -->
+<div class="tabs tabs-boxed mb-6 w-fit">
+    <a class="tab {{if ne .Filter "shared"}}tab-active{{end}}"
+       hx-get="/dashboard"
+       hx-target="#link-list"
+       hx-push-url="false">My Links</a>
+    <a class="tab {{if eq .Filter "shared"}}tab-active{{end}}"
+       hx-get="/dashboard?filter=shared"
+       hx-target="#link-list"
+       hx-push-url="false">Shared with me</a>
+</div>
+
 <!-- Governing: SPEC-0004 REQ "User Dashboard" — tag filter chips -->
 {{if .Tags}}
 <div class="flex flex-wrap gap-2 mb-6">

--- a/web/templates/partials/link_list.html
+++ b/web/templates/partials/link_list.html
@@ -10,6 +10,7 @@
                 {{if $.ShowTitle}}<th>Title</th>{{end}}
                 {{if $.ShowOwner}}<th>Owner(s)</th>{{end}}
                 {{if $.ShowTags}}<th>Tags</th>{{end}}
+                {{if $.ShowVisibility}}<th>Visibility</th>{{end}}
                 <th>Description</th>
                 <th>Created</th>
                 <th></th>
@@ -38,6 +39,9 @@
                 {{if $.ShowTitle}}<td class="text-sm text-base-content/70">{{.Title}}</td>{{end}}
                 {{if $.ShowOwner}}<td class="text-sm text-base-content/70">{{.Owners}}</td>{{end}}
                 {{if $.ShowTags}}<td class="text-sm">{{range .TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}</td>{{end}}
+                {{if $.ShowVisibility}}<td class="text-sm">
+                    <span class="badge badge-sm {{if eq .Visibility "secure"}}badge-error{{else if eq .Visibility "private"}}badge-warning{{else}}badge-ghost{{end}}">{{.Visibility}}</span>
+                </td>{{end}}
                 <td class="text-sm text-base-content/60">{{.Description}}</td>
                 <td class="text-sm text-base-content/60">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
                 <!-- Governing: SPEC-0014 REQ "Abstract Link Widget" — Edit and Delete actions only (no View) -->


### PR DESCRIPTION
## Summary
- **Resolver visibility enforcement**: Public and private links redirect as before. Secure links require authentication (redirect to login) and authorization (owner, co-owner, share, or admin) — returns 403 if unauthorized.
- **Dashboard "Shared with me" filter**: New tab on the dashboard that shows links shared with the current user via `link_shares`.
- **Admin visibility badges**: Visibility column added to admin links table with color-coded DaisyUI badges (ghost/warning/error). Admin inline edit form now includes a visibility selector.
- **Store methods**: `ListSharedWithUser` for shared-with-me queries, `UpdateVisibility` for admin visibility changes.

Closes #92 / Part of #90

Governing: SPEC-0010, ADR-0014

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (56 tests)
- [ ] Manual: visit a public link as anonymous user — should redirect (302)
- [ ] Manual: visit a private link as anonymous user — should redirect (302)
- [ ] Manual: visit a secure link as anonymous user — should redirect to login
- [ ] Manual: visit a secure link as authenticated non-owner — should show 403
- [ ] Manual: visit a secure link as owner/admin/shared user — should redirect (302)
- [ ] Manual: dashboard "Shared with me" tab shows correct links
- [ ] Manual: admin links table shows visibility badges
- [ ] Manual: admin inline edit can change visibility

Generated with [Claude Code](https://claude.com/claude-code)