### PR TITLE
Add visibility selector to link forms and share management panel (SPEC-0010)

### DIFF
--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -139,7 +139,7 @@ func (h *linksAPIHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	link, err := h.links.Create(r.Context(), req.Slug, req.URL, user.ID, req.Title, req.Description)
+	link, err := h.links.Create(r.Context(), req.Slug, req.URL, user.ID, req.Title, req.Description, "")
 	if err != nil {
 		if errors.Is(err, store.ErrSlugTaken) {
 			writeError(w, http.StatusConflict, "slug already exists", "SLUG_CONFLICT")
@@ -288,7 +288,7 @@ func (h *linksAPIHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	updated, err := h.links.Update(r.Context(), link.ID, req.URL, req.Title, req.Description)
+	updated, err := h.links.Update(r.Context(), link.ID, req.URL, req.Title, req.Description, link.Visibility)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
 		return

--- a/internal/api/links_test.go
+++ b/internal/api/links_test.go
@@ -17,7 +17,7 @@ func TestLinks_List_OK(t *testing.T) {
 	token := seedToken(t, env, user.ID)
 
 	// Create a link so the list isn't empty.
-	_, err := env.LinkStore.Create(context.Background(), "test-link", "https://example.com", user.ID, "Test", "")
+	_, err := env.LinkStore.Create(context.Background(), "test-link", "https://example.com", user.ID, "Test", "", "")
 	if err != nil {
 		t.Fatalf("create link: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestLinks_Create_DuplicateSlug(t *testing.T) {
 	token := seedToken(t, env, user.ID)
 
 	// Create first link.
-	_, err := env.LinkStore.Create(context.Background(), "dup-slug", "https://a.com", user.ID, "", "")
+	_, err := env.LinkStore.Create(context.Background(), "dup-slug", "https://a.com", user.ID, "", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestLinks_Get_Found(t *testing.T) {
 	user := seedUser(t, env, "alice@example.com", "user")
 	token := seedToken(t, env, user.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "get-me", "https://example.com", user.ID, "Get Me", "")
+	link, err := env.LinkStore.Create(context.Background(), "get-me", "https://example.com", user.ID, "Get Me", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestLinks_Get_Forbidden_NotOwner(t *testing.T) {
 	other := seedUser(t, env, "other@example.com", "user")
 	otherToken := seedToken(t, env, other.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "private-link", "https://example.com", owner.ID, "", "")
+	link, err := env.LinkStore.Create(context.Background(), "private-link", "https://example.com", owner.ID, "", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestLinks_Update_OK(t *testing.T) {
 	user := seedUser(t, env, "alice@example.com", "user")
 	token := seedToken(t, env, user.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "update-me", "https://old.com", user.ID, "Old", "Old desc")
+	link, err := env.LinkStore.Create(context.Background(), "update-me", "https://old.com", user.ID, "Old", "Old desc", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestLinks_Update_Forbidden_NotOwner(t *testing.T) {
 	other := seedUser(t, env, "other@example.com", "user")
 	otherToken := seedToken(t, env, other.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "no-update", "https://example.com", owner.ID, "", "")
+	link, err := env.LinkStore.Create(context.Background(), "no-update", "https://example.com", owner.ID, "", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestLinks_Delete_NoContent(t *testing.T) {
 	user := seedUser(t, env, "alice@example.com", "user")
 	token := seedToken(t, env, user.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "delete-me", "https://example.com", user.ID, "", "")
+	link, err := env.LinkStore.Create(context.Background(), "delete-me", "https://example.com", user.ID, "", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestLinks_Get_VariableURL_Passthrough(t *testing.T) {
 	user := seedUser(t, env, "alice@example.com", "user")
 	token := seedToken(t, env, user.ID)
 
-	link, err := env.LinkStore.Create(context.Background(), "var-link", "https://example.com/$query/$page", user.ID, "Var Link", "")
+	link, err := env.LinkStore.Create(context.Background(), "var-link", "https://example.com/$query/$page", user.ID, "Var Link", "", "")
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -168,7 +168,13 @@ func (h *AdminHandler) UpdateLink(w http.ResponseWriter, r *http.Request) {
 	title := r.FormValue("title")
 	description := r.FormValue("description")
 
-	_, err := h.links.Update(r.Context(), id, url, title, description)
+	// Preserve existing visibility for admin inline edits
+	existing, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	_, err = h.links.Update(r.Context(), id, url, title, description, existing.Visibility)
 	if err != nil {
 		http.Error(w, "update failed", http.StatusInternalServerError)
 		return

--- a/internal/handler/resolve_test.go
+++ b/internal/handler/resolve_test.go
@@ -41,7 +41,7 @@ func newResolveTestEnv(t *testing.T) *resolveTestEnv {
 // seedLink creates a link with the given slug and URL.
 func (e *resolveTestEnv) seedLink(t *testing.T, slug, url string) {
 	t.Helper()
-	_, err := e.ls.Create(context.Background(), slug, url, e.userID, "", "")
+	_, err := e.ls.Create(context.Background(), slug, url, e.userID, "", "", "")
 	if err != nil {
 		t.Fatalf("seed link %q: %v", slug, err)
 	}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -94,6 +94,10 @@ func NewRouter(deps Deps) http.Handler {
 		r.Post("/dashboard/links/{id}/owners", links.AddOwner)
 		r.Delete("/dashboard/links/{id}/owners/{uid}", links.RemoveOwner)
 
+		// Governing: SPEC-0010 REQ "Link Share Management Endpoints"
+		r.Post("/dashboard/links/{id}/shares", links.AddShare)
+		r.Delete("/dashboard/links/{id}/shares/{uid}", links.RemoveShare)
+
 		r.Get("/dashboard/tags", tags.Index)
 		r.Get("/dashboard/tags/suggest", tags.Suggest)
 		r.Get("/dashboard/tags/{slug}", tags.Detail)

--- a/internal/store/links_test.go
+++ b/internal/store/links_test.go
@@ -50,7 +50,7 @@ func TestLinkStore_Create(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	link, err := ls.Create(ctx, "my-link", "https://example.com", userID, "My Link", "A test link")
+	link, err := ls.Create(ctx, "my-link", "https://example.com", userID, "My Link", "A test link", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestLinkStore_GetBySlug(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	created, err := ls.Create(ctx, "get-test", "https://example.com", userID, "", "")
+	created, err := ls.Create(ctx, "get-test", "https://example.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -100,11 +100,11 @@ func TestLinkStore_ListAll(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	_, err := ls.Create(ctx, "aaa-link", "https://a.com", userID, "", "")
+	_, err := ls.Create(ctx, "aaa-link", "https://a.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	_, err = ls.Create(ctx, "bbb-link", "https://b.com", userID, "", "")
+	_, err = ls.Create(ctx, "bbb-link", "https://b.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestLinkStore_ListByOwner(t *testing.T) {
 	ls, _, us, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	_, err := ls.Create(ctx, "owned-link", "https://example.com", userID, "", "")
+	_, err := ls.Create(ctx, "owned-link", "https://example.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -158,12 +158,12 @@ func TestLinkStore_Update(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	created, err := ls.Create(ctx, "update-me", "https://old.com", userID, "Old", "Old desc")
+	created, err := ls.Create(ctx, "update-me", "https://old.com", userID, "Old", "Old desc", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
-	updated, err := ls.Update(ctx, created.ID, "https://new.com", "New", "New desc")
+	updated, err := ls.Update(ctx, created.ID, "https://new.com", "New", "New desc", "public")
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestLinkStore_Delete(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	created, err := ls.Create(ctx, "delete-me", "https://example.com", userID, "", "")
+	created, err := ls.Create(ctx, "delete-me", "https://example.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -205,12 +205,12 @@ func TestLinkStore_SlugUniqueness(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	_, err := ls.Create(ctx, "unique-slug", "https://a.com", userID, "", "")
+	_, err := ls.Create(ctx, "unique-slug", "https://a.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create first: %v", err)
 	}
 
-	_, err = ls.Create(ctx, "unique-slug", "https://b.com", userID, "", "")
+	_, err = ls.Create(ctx, "unique-slug", "https://b.com", userID, "", "", "")
 	if !errors.Is(err, store.ErrSlugTaken) {
 		t.Errorf("Create duplicate slug = %v, want ErrSlugTaken", err)
 	}
@@ -230,7 +230,7 @@ func TestLinkStore_SetAndListTags(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	link, err := ls.Create(ctx, "tagged-link", "https://example.com", userID, "", "")
+	link, err := ls.Create(ctx, "tagged-link", "https://example.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestLinkStore_ListByTag(t *testing.T) {
 	ls, _, _, userID := newTestEnv(t)
 	ctx := context.Background()
 
-	link, err := ls.Create(ctx, "tag-filter", "https://example.com", userID, "", "")
+	link, err := ls.Create(ctx, "tag-filter", "https://example.com", userID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -121,7 +121,7 @@ func TestTagStore_ListWithCounts(t *testing.T) {
 	}
 
 	// Create a link with a tag.
-	link, err := ls.Create(ctx, "counted", "https://example.com", u.ID, "", "")
+	link, err := ls.Create(ctx, "counted", "https://example.com", u.ID, "", "", "")
 	if err != nil {
 		t.Fatalf("Create link: %v", err)
 	}

--- a/web/templates/pages/links/detail.html
+++ b/web/templates/pages/links/detail.html
@@ -67,6 +67,9 @@
     </div>
 </div>
 
+<!-- Governing: SPEC-0010 REQ "Share Management Panel on Link Detail" -->
+{{template "shares_panel" .}}
+
 <!-- Governing: SPEC-0004 REQ "Delete Link" — confirm modal using DaisyUI dialog -->
 <dialog id="confirm-delete-modal" class="modal">
     <div class="modal-box">

--- a/web/templates/pages/links/edit.html
+++ b/web/templates/pages/links/edit.html
@@ -46,6 +46,16 @@
                         value="{{if .Form.Description}}{{.Form.Description}}{{else}}{{.Link.Description}}{{end}}">
                 </div>
 
+                <!-- Governing: SPEC-0010 REQ "Visibility Selector in Link Forms" -->
+                <div class="form-control mb-4">
+                    <label class="label"><span class="label-text">Visibility</span></label>
+                    <select name="visibility" class="select select-bordered">
+                        <option value="public" {{if eq .Form.Visibility "public"}}selected{{end}}>Public — anyone can access</option>
+                        <option value="private" {{if eq .Form.Visibility "private"}}selected{{end}}>Private — hidden from browsing</option>
+                        <option value="secure" {{if eq .Form.Visibility "secure"}}selected{{end}}>Secure — requires login + grant</option>
+                    </select>
+                </div>
+
                 <div class="form-control mb-6">
                     <label class="label">
                         <span class="label-text">Tags</span>

--- a/web/templates/pages/links/new.html
+++ b/web/templates/pages/links/new.html
@@ -85,6 +85,16 @@
                     >
                 </div>
 
+                <!-- Governing: SPEC-0010 REQ "Visibility Selector in Link Forms" -->
+                <div class="form-control mb-4">
+                    <label class="label"><span class="label-text">Visibility</span></label>
+                    <select name="visibility" class="select select-bordered">
+                        <option value="public" {{if eq .Form.Visibility "public"}}selected{{end}}>Public — anyone can access</option>
+                        <option value="private" {{if eq .Form.Visibility "private"}}selected{{end}}>Private — hidden from browsing</option>
+                        <option value="secure" {{if eq .Form.Visibility "secure"}}selected{{end}}>Secure — requires login + grant</option>
+                    </select>
+                </div>
+
                 <!-- Governing: SPEC-0004 REQ "New Link Form" — tag input with autocomplete -->
                 <div class="form-control mb-6">
                     <label class="label">

--- a/web/templates/partials/modal_form.html
+++ b/web/templates/partials/modal_form.html
@@ -86,6 +86,16 @@
                 >
             </div>
 
+            <!-- Governing: SPEC-0010 REQ "Visibility Selector in Link Forms" -->
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Visibility</span></label>
+                <select name="visibility" class="select select-bordered">
+                    <option value="public" {{if eq .Form.Visibility "public"}}selected{{end}}>Public — anyone can access</option>
+                    <option value="private" {{if eq .Form.Visibility "private"}}selected{{end}}>Private — hidden from browsing</option>
+                    <option value="secure" {{if eq .Form.Visibility "secure"}}selected{{end}}>Secure — requires login + grant</option>
+                </select>
+            </div>
+
             <div class="form-control mb-6">
                 <label class="label">
                     <span class="label-text">Tags</span>
@@ -172,6 +182,16 @@ function addTag(name) {
                 <label class="label"><span class="label-text">Description</span></label>
                 <input type="text" name="description" class="input input-bordered"
                     value="{{if .Form.Description}}{{.Form.Description}}{{else}}{{.Link.Description}}{{end}}">
+            </div>
+
+            <!-- Governing: SPEC-0010 REQ "Visibility Selector in Link Forms" -->
+            <div class="form-control mb-4">
+                <label class="label"><span class="label-text">Visibility</span></label>
+                <select name="visibility" class="select select-bordered">
+                    <option value="public" {{if eq .Form.Visibility "public"}}selected{{end}}>Public — anyone can access</option>
+                    <option value="private" {{if eq .Form.Visibility "private"}}selected{{end}}>Private — hidden from browsing</option>
+                    <option value="secure" {{if eq .Form.Visibility "secure"}}selected{{end}}>Secure — requires login + grant</option>
+                </select>
             </div>
 
             <div class="form-control mb-6">

--- a/web/templates/partials/shares_panel.html
+++ b/web/templates/partials/shares_panel.html
@@ -1,0 +1,57 @@
+{{define "shares_panel"}}
+<!-- Governing: SPEC-0010 REQ "Share Management Panel on Link Detail" -->
+{{if eq .Link.Visibility "secure"}}
+<div id="shares-panel" class="card bg-base-200 shadow mt-4">
+    <div class="card-body">
+        <h2 class="card-title text-lg">Shared with</h2>
+
+        {{if .Error}}
+        <div class="alert alert-error mb-3 text-sm">
+            <span>{{.Error}}</span>
+        </div>
+        {{end}}
+
+        {{if .Shares}}
+        <div class="overflow-x-auto mb-4">
+            <table class="table table-sm">
+                <tbody>
+                    {{range .Shares}}
+                    <tr>
+                        <td>
+                            <div class="flex items-center gap-2">
+                                <div class="avatar placeholder">
+                                    <div class="bg-neutral text-neutral-content rounded-full w-6">
+                                        <span class="text-xs">{{slice .DisplayName 0 1}}</span>
+                                    </div>
+                                </div>
+                                <span>{{.DisplayName}}</span>
+                                <span class="text-xs text-base-content/50">{{.Email}}</span>
+                            </div>
+                        </td>
+                        <td class="text-right">
+                            <button class="btn btn-xs btn-ghost btn-error"
+                                    hx-delete="/dashboard/links/{{$.Link.ID}}/shares/{{.UserID}}"
+                                    hx-target="#shares-panel"
+                                    hx-swap="outerHTML">Remove</button>
+                        </td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+        {{else}}
+        <p class="text-sm opacity-60 mb-4">No users with access yet.</p>
+        {{end}}
+
+        <form hx-post="/dashboard/links/{{.Link.ID}}/shares"
+              hx-target="#shares-panel"
+              hx-swap="outerHTML"
+              class="flex gap-2">
+            <input type="email" name="email" class="input input-bordered input-sm flex-1"
+                   placeholder="Add user by email" required>
+            <button type="submit" class="btn btn-sm btn-primary">Add</button>
+        </form>
+    </div>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary
- Adds a visibility selector (public/private/secure) to both the new link and edit link forms, including their HTMX modal variants
- Adds a "Shared with" panel on the link detail page, shown only for secure links, with add/remove user capabilities via HTMX
- Updates `LinkStore.Create` and `Update` to accept and persist visibility values
- Registers `POST /dashboard/links/{id}/shares` and `DELETE /dashboard/links/{id}/shares/{uid}` routes with owner/admin authorization

Closes #93 / Part of #90

Governing: SPEC-0010 REQ "Visibility Selector in Link Forms", REQ "Share Management Panel on Link Detail", REQ "Link Share Management Endpoints"

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 56+ tests)
- [ ] Verify visibility selector appears in new link form and defaults to "public"
- [ ] Verify visibility selector appears in edit form with current value pre-selected
- [ ] Verify "Shared with" panel appears only when link visibility is "secure"
- [ ] Verify adding a user by email to shares panel works via HTMX
- [ ] Verify removing a user from shares panel works via HTMX
- [ ] Verify non-owners cannot manage shares (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)