### PR TITLE
Browser Action Popup — One-Click Link Creation

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,8 @@
     "storage",
     "tabs",
     "webNavigation",
-    "alarms"
+    "alarms",
+    "activeTab"
   ],
   "host_permissions": [
     "<all_urls>"
@@ -26,7 +27,8 @@
       "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
     },
-    "default_title": "joe-links"
+    "default_title": "joe-links",
+    "default_popup": "popup.html"
   },
   "options_ui": {
     "page": "options.html",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Create Link — joe-links</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      width: 300px;
+      margin: 0;
+      padding: 16px;
+      color: #1a1a1a;
+    }
+    h1 { font-size: 0.95rem; margin: 0 0 12px; font-weight: 600; }
+    label { display: block; margin-bottom: 0.25rem; font-weight: 600; font-size: 0.8rem; }
+    input[type="text"] {
+      width: 100%; box-sizing: border-box;
+      padding: 6px 8px; font-size: 0.85rem;
+      border: 1px solid #ccc; border-radius: 4px;
+      outline: none; margin-bottom: 8px;
+    }
+    input[type="text"]:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59,130,246,.2); }
+    .row { display: flex; gap: 6px; }
+    .row input { margin-bottom: 0; }
+    .hint { font-size: 0.75rem; color: #888; margin: -4px 0 8px; }
+    button {
+      width: 100%; padding: 7px; font-size: 0.9rem;
+      background: #3b82f6; color: #fff;
+      border: none; border-radius: 4px; cursor: pointer;
+      margin-top: 4px;
+    }
+    button:hover { background: #2563eb; }
+    button:disabled { background: #93c5fd; cursor: not-allowed; }
+    #status { margin-top: 8px; font-size: 0.85rem; display: none; }
+    #status.success { color: #16a34a; }
+    #status.error { color: #dc2626; }
+    #created-link { font-family: monospace; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <!-- Governing: SPEC-0008 REQ "Browser Action — Create Link", ADR-0012 -->
+  <h1>Create short link</h1>
+
+  <label for="url">Destination URL</label>
+  <input type="text" id="url" placeholder="https://example.com/long/url" />
+
+  <div class="row">
+    <div style="flex:1">
+      <label for="keyword">Keyword (optional)</label>
+      <input type="text" id="keyword" placeholder="go" />
+    </div>
+    <div style="flex:1">
+      <label for="slug">Slug</label>
+      <input type="text" id="slug" placeholder="my-link" />
+    </div>
+  </div>
+  <p class="hint">Creates: keyword/slug → URL</p>
+
+  <button id="create">Create Link</button>
+
+  <div id="status">
+    <span id="status-msg"></span>
+    <span id="created-link"></span>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,79 @@
+// Governing: SPEC-0008 REQ "Browser Action — Create Link", ADR-0012
+'use strict';
+
+const DEFAULTS = { baseURL: 'http://go', apiKey: '' };
+
+// Pre-fill the current tab's URL.
+// Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "popup opens"
+chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+  if (tabs[0]?.url) {
+    document.getElementById('url').value = tabs[0].url;
+  }
+});
+
+document.getElementById('create').addEventListener('click', async () => {
+  const urlInput = document.getElementById('url');
+  const slugInput = document.getElementById('slug');
+  const keywordInput = document.getElementById('keyword');
+  const btn = document.getElementById('create');
+  const statusDiv = document.getElementById('status');
+  const statusMsg = document.getElementById('status-msg');
+  const createdLink = document.getElementById('created-link');
+
+  const url = urlInput.value.trim();
+  const slug = slugInput.value.trim();
+  const keyword = keywordInput.value.trim();
+
+  if (!url || !slug) {
+    showStatus('error', 'URL and slug are required.');
+    return;
+  }
+
+  btn.disabled = true;
+  btn.textContent = 'Creating…';
+  statusDiv.style.display = 'none';
+
+  const { baseURL, apiKey } = await chrome.storage.local.get(DEFAULTS);
+  const headers = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+  const body = { url, slug };
+  if (keyword) body.keyword = keyword;
+
+  try {
+    // Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "submit form"
+    const res = await fetch(`${baseURL}/api/v1/links`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      const linkText = keyword ? `${keyword}/${data.slug || slug}` : (data.slug || slug);
+      showStatus('success', 'Created: ', linkText);
+      slugInput.value = '';
+    } else {
+      const errData = await res.json().catch(() => ({}));
+      const msg = errData.error || errData.message || `Error ${res.status}`;
+      // Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "POST fails"
+      showStatus('error', msg);
+    }
+  } catch (err) {
+    showStatus('error', err.message || 'Network error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Create Link';
+  }
+});
+
+function showStatus(type, msg, link) {
+  const statusDiv = document.getElementById('status');
+  const statusMsg = document.getElementById('status-msg');
+  const createdLink = document.getElementById('created-link');
+  statusMsg.textContent = msg;
+  createdLink.textContent = link || '';
+  statusDiv.className = type;
+  statusDiv.style.display = 'block';
+}


### PR DESCRIPTION
## Summary
- Adds `popup.html` + `popup.js`: 300px browser action popup for creating short links
- Pre-fills current tab's URL in the destination field on open
- Keyword (optional) + slug fields; POSTs to `/api/v1/links` with stored API key
- Shows created `keyword/slug` on success, error message on failure
- `manifest.json`: `action.default_popup` + `activeTab` permission added

Closes #117
Governing: SPEC-0008 REQ "Browser Action — Create Link", ADR-0012