### PR TITLE
Add no-API-key notice to browser extension popup

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -101,6 +101,22 @@
     button#create:hover { background: var(--primary-hover); }
     button#create:disabled { opacity: 0.5; cursor: not-allowed; }
     #status { display: none; }
+    #no-api-key {
+      display: none;
+      border-radius: var(--radius);
+      border: 1px solid var(--error-border);
+      background: var(--error-bg);
+      color: var(--error-text);
+      padding: 10px 12px;
+      font-size: 0.82rem;
+      line-height: 1.4;
+    }
+    #no-api-key a {
+      color: var(--primary);
+      font-weight: 600;
+      text-decoration: underline;
+      cursor: pointer;
+    }
     .status-box {
       border-radius: var(--radius);
       border: 1px solid;
@@ -134,6 +150,10 @@
     joe-links
   </div>
   <div class="body">
+    <!-- Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "no API key" -->
+    <div id="no-api-key">
+      No API key configured. <a id="open-options">Configure an API key</a> in the extension options to create links.
+    </div>
     <div class="field">
       <label for="url">Destination URL</label>
       <input type="text" id="url" placeholder="https://example.com/long/url" />

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -3,6 +3,19 @@
 
 const DEFAULTS = { baseURL: 'http://go', apiKey: '' };
 
+// Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "no API key"
+// When no API key is configured, show a notice directing user to options page.
+document.addEventListener('DOMContentLoaded', async () => {
+  const { apiKey } = await chrome.storage.local.get(DEFAULTS);
+  if (!apiKey) {
+    document.getElementById('no-api-key').style.display = 'block';
+    document.getElementById('create').disabled = true;
+  }
+  document.getElementById('open-options').addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
+  });
+});
+
 // Pre-fill the current tab's URL.
 // Governing: SPEC-0008 REQ "Browser Action — Create Link" scenario "popup opens"
 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {


### PR DESCRIPTION
## Summary
- On popup load, check if `apiKey` is set in `chrome.storage.local`
- If no API key is configured, display a styled error notice directing the user to the extension options page
- Disable the "Create Link" button when no API key is present to prevent blind submissions
- Notice uses existing color variables (error theme) and respects dark mode

## Governing
- SPEC-0008 REQ "Browser Action — Create Link" scenario "no API key"
- ADR-0012

Closes #127
Part of #122 (SPEC-0008)

## Test plan
- [ ] Load the extension with no API key configured — notice should appear and button should be disabled
- [ ] Click "Configure an API key" link — should open the extension options page
- [ ] Configure an API key in options — reload popup, notice should be hidden and button enabled
- [ ] Verify notice styling in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)