### PR TITLE
SPEC-0014: Link List UI Consistency — unified partial and admin keywords UI

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -87,7 +87,7 @@
                     </svg>
                     Links
                 </a>
-                <!-- Governing: SPEC-0014 -->
+                <!-- Governing: SPEC-0014 REQ "Keywords Admin Sidebar Link" -->
                 <a href="/admin/keywords" data-nav="/admin/keywords"
                    class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium hover:bg-base-300 transition-colors">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/web/templates/pages/admin/keywords.html
+++ b/web/templates/pages/admin/keywords.html
@@ -49,7 +49,7 @@
         <td class="text-sm font-mono">{{.URLTemplate}}</td>
         <td class="text-sm text-base-content/70">{{.Description}}</td>
         <td>
-            <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal", SPEC-0014 -->
+            <!-- Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal", SPEC-0014 REQ "Keywords Delete Icon Button" -->
             <button class="btn btn-xs btn-ghost text-error tooltip tooltip-left"
                     data-tip="Delete"
                     hx-get="/admin/keywords/{{.ID}}/confirm-delete"


### PR DESCRIPTION
Traceability PR for SPEC-0014 link list UI consistency work, already implemented in main.

## Changes
- Unified `link_list` partial with configurable Show* column flags (SPEC-0014)
- Keyword/slug display with muted prefix and inline copy button (SPEC-0014)
- Keywords link in admin sidebar with SPEC-0014 REQ label (SPEC-0014)
- Trash icon delete button on keyword rows with SPEC-0014 REQ label (SPEC-0014)

## Governing
Governing: SPEC-0014 — Link List UI Consistency

Closes #123
Closes #124
Part of #121 (SPEC-0014)