### PR TITLE
Data Model & Click Recording

### DIFF
--- a/internal/db/migrations/00012_create_link_clicks.sql
+++ b/internal/db/migrations/00012_create_link_clicks.sql
@@ -1,0 +1,17 @@
+-- Governing: SPEC-0016 REQ "Click Data Schema", ADR-0016
+-- +goose Up
+CREATE TABLE IF NOT EXISTS link_clicks (
+    id TEXT NOT NULL PRIMARY KEY,
+    link_id TEXT NOT NULL REFERENCES links(id) ON DELETE CASCADE,
+    user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+    ip_hash TEXT NOT NULL,
+    user_agent TEXT,
+    referrer TEXT,
+    clicked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_link_clicks_link_id_clicked_at ON link_clicks(link_id, clicked_at DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_link_clicks_link_id_clicked_at;
+DROP TABLE IF EXISTS link_clicks;

--- a/internal/handler/resolve_test.go
+++ b/internal/handler/resolve_test.go
@@ -34,7 +34,7 @@ func newResolveTestEnv(t *testing.T) *resolveTestEnv {
 		t.Fatalf("seed user: %v", err)
 	}
 
-	rh := NewResolveHandler(ls, ks, owns)
+	rh := NewResolveHandler(ls, ks, owns, nil)
 	return &resolveTestEnv{ls: ls, ks: ks, rh: rh, userID: u.ID}
 }
 

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -32,6 +32,8 @@ type Deps struct {
 	UserStore      *store.UserStore
 	TokenStore     auth.TokenStore
 	KeywordStore   *store.KeywordStore
+	ClickStore     *store.ClickStore   // Governing: SPEC-0016 REQ "Click Recording", ADR-0016
+	ClickCh        chan<- store.ClickEvent // Governing: SPEC-0016 REQ "Click Recording", ADR-0016
 	ShortKeyword   string // optional override (e.g. "go"); defaults to first label of HTTP host
 }
 
@@ -183,7 +185,7 @@ func NewRouter(deps Deps) http.Handler {
 	// Governing: SPEC-0004 REQ "Route Registration and Priority" — catch-all AFTER named routes
 	// Governing: SPEC-0009 REQ "Multi-Segment Path Resolution", ADR-0013 — wildcard for multi-segment paths
 	// Governing: SPEC-0010 REQ "Secure Link Resolution" — resolver needs OwnershipStore for access checks
-	resolver := NewResolveHandler(deps.LinkStore, deps.KeywordStore, deps.OwnershipStore)
+	resolver := NewResolveHandler(deps.LinkStore, deps.KeywordStore, deps.OwnershipStore, deps.ClickCh)
 	r.With(deps.AuthMiddleware.OptionalUser).Get("/{slug}*", resolver.Resolve)
 
 	return r

--- a/internal/store/click_store.go
+++ b/internal/store/click_store.go
@@ -1,0 +1,135 @@
+// Governing: SPEC-0016 REQ "Click Data Schema", REQ "Click Recording", ADR-0016
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// ClickEvent represents a single click to be recorded.
+type ClickEvent struct {
+	LinkID    string
+	UserID    string // empty string = anonymous
+	IPHash    string // caller computes this
+	UserAgent string
+	Referrer  string
+}
+
+// ClickStats holds aggregate click counts for a link.
+type ClickStats struct {
+	Total  int64
+	Last7d int64
+	Last30d int64
+}
+
+// RecentClick represents a single click with optional user info.
+type RecentClick struct {
+	ClickedAt   time.Time `db:"clicked_at"`
+	Referrer    string    `db:"referrer"`
+	UserID      string    `db:"user_id"`
+	DisplayName string    `db:"display_name"`
+}
+
+// ClickStore is the sqlx-backed store for click tracking operations.
+type ClickStore struct {
+	db *sqlx.DB
+}
+
+// NewClickStore creates a new ClickStore.
+func NewClickStore(db *sqlx.DB) *ClickStore {
+	return &ClickStore{db: db}
+}
+
+// q rebinds ? placeholders to the driver's native format.
+func (s *ClickStore) q(query string) string { return s.db.Rebind(query) }
+
+// RecordClick inserts a click event row.
+// Governing: SPEC-0016 REQ "Click Recording", ADR-0016
+func (s *ClickStore) RecordClick(ctx context.Context, e ClickEvent) error {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+
+	// Truncate user_agent to 512 chars, referrer to 2048.
+	ua := e.UserAgent
+	if len(ua) > 512 {
+		ua = ua[:512]
+	}
+	ref := e.Referrer
+	if len(ref) > 2048 {
+		ref = ref[:2048]
+	}
+
+	var userID interface{}
+	if e.UserID != "" {
+		userID = e.UserID
+	}
+
+	_, err := s.db.ExecContext(ctx, s.q(`
+		INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`), id, e.LinkID, userID, e.IPHash, ua, ref, now)
+	return err
+}
+
+// GetClickStats returns total, 7d, and 30d click counts for a link.
+// Governing: SPEC-0016 REQ "Click Data Schema", ADR-0016
+func (s *ClickStore) GetClickStats(ctx context.Context, linkID string) (ClickStats, error) {
+	var stats ClickStats
+	now := time.Now().UTC()
+	since7d := now.AddDate(0, 0, -7)
+	since30d := now.AddDate(0, 0, -30)
+
+	err := s.db.GetContext(ctx, &stats.Total,
+		s.q(`SELECT COUNT(*) FROM link_clicks WHERE link_id = ?`), linkID)
+	if err != nil {
+		return stats, err
+	}
+
+	err = s.db.GetContext(ctx, &stats.Last7d,
+		s.q(`SELECT COUNT(*) FROM link_clicks WHERE link_id = ? AND clicked_at >= ?`), linkID, since7d)
+	if err != nil {
+		return stats, err
+	}
+
+	err = s.db.GetContext(ctx, &stats.Last30d,
+		s.q(`SELECT COUNT(*) FROM link_clicks WHERE link_id = ? AND clicked_at >= ?`), linkID, since30d)
+	if err != nil {
+		return stats, err
+	}
+
+	return stats, nil
+}
+
+// ListRecentClicks returns the most recent N clicks for a link, joining users for display_name.
+// Governing: SPEC-0016 REQ "Click Data Schema", ADR-0016
+func (s *ClickStore) ListRecentClicks(ctx context.Context, linkID string, limit int) ([]RecentClick, error) {
+	var clicks []RecentClick
+	err := s.db.SelectContext(ctx, &clicks, s.q(`
+		SELECT c.clicked_at,
+		       COALESCE(c.referrer, '') AS referrer,
+		       COALESCE(c.user_id, '') AS user_id,
+		       COALESCE(u.display_name, '') AS display_name
+		FROM link_clicks c
+		LEFT JOIN users u ON u.id = c.user_id
+		WHERE c.link_id = ?
+		ORDER BY c.clicked_at DESC
+		LIMIT ?
+	`), linkID, limit)
+	if err != nil {
+		return nil, err
+	}
+	return clicks, nil
+}
+
+// HashIP computes SHA-256(ip + ":" + YYYYMMDD_UTC) for the current day.
+// Governing: SPEC-0016 REQ "Click Recording", ADR-0016
+func HashIP(ip string) string {
+	salt := time.Now().UTC().Format("20060102")
+	h := sha256.Sum256([]byte(ip + ":" + salt))
+	return fmt.Sprintf("%x", h)
+}


### PR DESCRIPTION
## Summary

Closes #137
Part of #136 (SPEC-0016)

- Add `link_clicks` table migration (`00012_create_link_clicks.sql`) with composite index on `(link_id, clicked_at DESC)`
- Add `ClickStore` with `RecordClick`, `GetClickStats` (total/7d/30d), and `ListRecentClicks` (LEFT JOIN users for display_name)
- Add `HashIP` helper — daily-salted SHA-256 for privacy-preserving IP hashing
- Wire async click recording into `ResolveHandler.redirect()` via buffered channel (capacity 256) with non-blocking send
- Add `runClickWriter` goroutine in `serve.go` that drains the channel on shutdown
- Add `realIP` helper checking X-Real-IP, X-Forwarded-For, then RemoteAddr
- Only slug-resolved redirects record clicks (keyword redirects are excluded)

### Governing

- SPEC-0016 REQ "Click Data Schema", REQ "Click Recording"
- ADR-0016

## Test plan

- [x] All existing tests pass (`go test ./... -count=1`)
- [ ] Manual: verify `link_clicks` table is created on startup with SQLite
- [ ] Manual: verify redirect records a click row
- [ ] Manual: verify keyword redirects do NOT record clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)