### PR TITLE
Dashboard Stats Page

### DIFF
--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -83,6 +83,8 @@ func NewRouter(deps Deps) http.Handler {
 	links := NewLinksHandler(deps.LinkStore, deps.OwnershipStore, deps.UserStore, deps.KeywordStore)
 	tags := NewTagsHandler(deps.TagStore, deps.LinkStore, deps.KeywordStore)
 	tokensWeb := NewTokensHandler(deps.TokenStore)
+	// Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016
+	statsHandler := NewStatsHandler(deps.LinkStore, deps.ClickStore, deps.OwnershipStore)
 
 	r.Group(func(r chi.Router) {
 		r.Use(deps.AuthMiddleware.RequireAuth)
@@ -95,6 +97,8 @@ func NewRouter(deps Deps) http.Handler {
 		r.Post("/dashboard/links", links.Create)
 		r.Get("/dashboard/links/{id}", links.Detail)
 		r.Get("/dashboard/links/{id}/edit", links.Edit)
+		// Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016
+		r.Get("/dashboard/links/{id}/stats", statsHandler.Show)
 		// Governing: SPEC-0013 REQ "DaisyUI Delete Confirmation Modal"
 		r.Get("/dashboard/links/{id}/confirm-delete", links.ConfirmDelete)
 		r.Put("/dashboard/links/{id}", links.Update)

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -1,0 +1,86 @@
+// Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016
+package handler
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// StatsPage is the template data for the link analytics view.
+// Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016
+type StatsPage struct {
+	BasePage
+	User         *store.User
+	Link         *store.Link
+	Stats        store.ClickStats
+	RecentClicks []store.RecentClick
+}
+
+// StatsHandler serves the per-link analytics page.
+type StatsHandler struct {
+	links  *store.LinkStore
+	clicks *store.ClickStore
+	owns   *store.OwnershipStore
+}
+
+// NewStatsHandler creates a new StatsHandler.
+func NewStatsHandler(ls *store.LinkStore, cs *store.ClickStore, os *store.OwnershipStore) *StatsHandler {
+	return &StatsHandler{links: ls, clicks: cs, owns: os}
+}
+
+// Show renders the stats page for a single link.
+// Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016
+func (h *StatsHandler) Show(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Redirect(w, r, "/auth/login?redirect="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	link, err := h.links.GetByID(r.Context(), id)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Check ownership: user must be owner/co-owner or admin
+	if !user.IsAdmin() {
+		isOwner, _ := h.owns.IsOwner(link.ID, user.ID)
+		if !isOwner {
+			w.WriteHeader(http.StatusForbidden)
+			render(w, "403.html", newBasePage(r, user))
+			return
+		}
+	}
+
+	stats, err := h.clicks.GetClickStats(r.Context(), link.ID)
+	if err != nil {
+		http.Error(w, "could not load stats", http.StatusInternalServerError)
+		return
+	}
+
+	recent, err := h.clicks.ListRecentClicks(r.Context(), link.ID, 50)
+	if err != nil {
+		http.Error(w, "could not load recent clicks", http.StatusInternalServerError)
+		return
+	}
+
+	data := StatsPage{
+		BasePage:     newBasePage(r, user),
+		User:         user,
+		Link:         link,
+		Stats:        stats,
+		RecentClicks: recent,
+	}
+
+	if isHTMX(r) {
+		renderPageFragment(w, "links/stats.html", "content", data)
+		return
+	}
+	render(w, "links/stats.html", data)
+}

--- a/web/templates/pages/links/stats.html
+++ b/web/templates/pages/links/stats.html
@@ -1,0 +1,63 @@
+{{template "base" .}}
+{{define "title"}}{{if .Link}}{{.Link.Slug}} — Analytics{{end}} — Joe Links{{end}}
+{{define "content"}}
+<!-- Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016 -->
+{{if .Link}}
+<div class="max-w-5xl mx-auto">
+    <div class="flex items-center gap-3 mb-6">
+        <a href="/dashboard/links/{{.Link.ID}}" class="btn btn-ghost btn-sm">&larr; Back to link</a>
+        <h1 class="text-2xl font-bold"><span class="font-mono">{{.Link.Slug}}</span> &mdash; Analytics</h1>
+    </div>
+
+    <!-- Stat cards -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div class="stat bg-base-200 rounded-box shadow">
+            <div class="stat-title">All Time</div>
+            <div class="stat-value">{{.Stats.Total}}</div>
+            <div class="stat-desc">total clicks</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box shadow">
+            <div class="stat-title">Last 7 Days</div>
+            <div class="stat-value">{{.Stats.Last7d}}</div>
+            <div class="stat-desc">clicks this week</div>
+        </div>
+        <div class="stat bg-base-200 rounded-box shadow">
+            <div class="stat-title">Last 30 Days</div>
+            <div class="stat-value">{{.Stats.Last30d}}</div>
+            <div class="stat-desc">clicks this month</div>
+        </div>
+    </div>
+
+    <!-- Recent clicks table -->
+    <div class="card bg-base-200 shadow">
+        <div class="card-body">
+            <h2 class="card-title text-lg mb-4">Recent Clicks</h2>
+            {{if .RecentClicks}}
+            <div class="overflow-x-auto">
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>Time</th>
+                            <th>Referrer</th>
+                            <th>User</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{range .RecentClicks}}
+                        <tr>
+                            <td class="whitespace-nowrap">{{.ClickedAt.Format "Jan 2, 2006 3:04 PM"}}</td>
+                            <td class="truncate max-w-xs">{{if .Referrer}}{{.Referrer}}{{else}}<span class="text-base-content/40">direct</span>{{end}}</td>
+                            <td>{{if .DisplayName}}{{.DisplayName}}{{else}}<span class="text-base-content/40">anonymous</span>{{end}}</td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+            </div>
+            {{else}}
+            <p class="text-base-content/50">No clicks recorded yet.</p>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
## Summary
- Adds per-link analytics page at `/dashboard/links/{id}/stats`
- Shows DaisyUI stat cards for all-time, 7-day, and 30-day click counts
- Displays table of 50 most recent clicks with time, referrer, and user
- Ownership check: only link owners and admins can view stats

Closes #139
Part of #136 (SPEC-0016)
Depends on #141 (click data model and recording)

## Test plan
- [x] All existing tests pass (`go test ./... -count=1`)
- [ ] Navigate to `/dashboard/links/{id}/stats` for an owned link — verify stat cards render
- [ ] Verify recent clicks table shows entries after clicking a link
- [ ] Verify empty state message when no clicks exist
- [ ] Verify non-owners get 403 Forbidden
- [ ] Verify admins can view stats for any link
- [ ] Verify HTMX partial rendering works (navigate via HTMX link)

Governing: SPEC-0016 REQ "Link Stats Dashboard Page", ADR-0016

🤖 Generated with [Claude Code](https://claude.com/claude-code)