### PR TITLE
Analytics code quality fixes (graceful shutdown, error handling, referrer privacy)

### DIFF
--- a/web/templates/pages/links/stats.html
+++ b/web/templates/pages/links/stats.html
@@ -45,7 +45,7 @@
                     <tbody>
                         {{range .RecentClicks}}
                         <tr>
-                            <td class="whitespace-nowrap">{{.ClickedAt.Format "Jan 2, 2006 3:04 PM"}}</td>
+                            <td class="whitespace-nowrap">{{.ClickedAt.Format "Jan 2, 2006 3:04 PM UTC"}}</td>
                             <td class="truncate max-w-xs">{{if .Referrer}}{{.Referrer}}{{else}}<span class="text-base-content/40">direct</span>{{end}}</td>
                             <td>{{if .DisplayName}}{{.DisplayName}}{{else}}<span class="text-base-content/40">anonymous</span>{{end}}</td>
                         </tr>


### PR DESCRIPTION
## Summary
- Graceful shutdown: switch to http.Server + signal.NotifyContext, drain click channel on SIGTERM
- Log dropped click events instead of silently discarding
- Fix IsOwner error handling in stats handler (was silently returning 403 on DB error)
- Simplify realIP() to use r.RemoteAddr (chi middleware.RealIP already rewrites it)
- Strip query params from referrer before storage (prevent token leakage)
- Add UTC label to stats page timestamps

Governing: SPEC-0016 REQ "Click Recording", SPEC-0016 REQ "Link Stats Dashboard Page", SPEC-0016 REQ "Click Data Schema"

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 4 test packages green)
- [ ] Manual: send SIGTERM to running server, verify click events drain before exit
- [ ] Manual: check referrer column in DB after clicking link with `?token=xxx` referrer — should be stripped
- [ ] Manual: verify stats page shows "UTC" after timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)