### PR TITLE
Add ClickStore and API stats tests (SPEC-0016)

### DIFF
--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -1,0 +1,455 @@
+// Governing: SPEC-0016 REQ "REST API Stats Endpoint", SPEC-0016 REQ "REST API Clicks Endpoint"
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// -- GET /api/v1/links/{id}/stats --
+
+func TestStats_Owner_OK(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "stats-owner@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "stats-link", "https://example.com", user.ID, "Stats", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	// Record a click.
+	err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+		LinkID: link.ID, UserID: user.ID, IPHash: "h1", UserAgent: "Test/1", Referrer: "https://ref.com",
+	})
+	if err != nil {
+		t.Fatalf("record click: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/stats", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		LinkID  string `json:"link_id"`
+		Total   int64  `json:"total"`
+		Last7d  int64  `json:"last_7d"`
+		Last30d int64  `json:"last_30d"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.LinkID != link.ID {
+		t.Errorf("link_id = %q, want %q", resp.LinkID, link.ID)
+	}
+	if resp.Total != 1 {
+		t.Errorf("total = %d, want 1", resp.Total)
+	}
+	if resp.Last7d != 1 {
+		t.Errorf("last_7d = %d, want 1", resp.Last7d)
+	}
+	if resp.Last30d != 1 {
+		t.Errorf("last_30d = %d, want 1", resp.Last30d)
+	}
+}
+
+func TestStats_NonOwner_Forbidden(t *testing.T) {
+	env := newTestEnv(t)
+	owner := seedUser(t, env, "stats-owner2@example.com", "user")
+	other := seedUser(t, env, "stats-other@example.com", "user")
+	otherToken := seedToken(t, env, other.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "stats-forbidden", "https://example.com", owner.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/stats", nil)
+	authRequest(req, otherToken)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestStats_Unauthenticated(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest("GET", "/links/some-id/stats", nil)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestStats_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "stats-nf@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	req := httptest.NewRequest("GET", "/links/nonexistent-id/stats", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// -- GET /api/v1/links/{id}/clicks --
+
+func TestClicks_OK_Structure(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-owner@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-link", "https://example.com", user.ID, "Clicks", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+		LinkID: link.ID, UserID: user.ID, IPHash: "h1", UserAgent: "Test/1", Referrer: "https://ref.com",
+	})
+	if err != nil {
+		t.Fatalf("record click: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Clicks []struct {
+			ClickedAt time.Time `json:"clicked_at"`
+			Referrer  *string   `json:"referrer"`
+			User      *struct {
+				ID          string `json:"id"`
+				DisplayName string `json:"display_name"`
+			} `json:"user"`
+		} `json:"clicks"`
+		NextCursor *string `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Clicks) != 1 {
+		t.Fatalf("len(clicks) = %d, want 1", len(resp.Clicks))
+	}
+	c := resp.Clicks[0]
+	if c.Referrer == nil {
+		t.Error("referrer should not be nil for click with referrer")
+	} else if *c.Referrer != "https://ref.com" {
+		t.Errorf("referrer = %q, want %q", *c.Referrer, "https://ref.com")
+	}
+	if c.User == nil {
+		t.Fatal("user should not be nil for authenticated click")
+	}
+	if c.User.ID != user.ID {
+		t.Errorf("user.id = %q, want %q", c.User.ID, user.ID)
+	}
+	if resp.NextCursor != nil {
+		t.Errorf("next_cursor should be nil when all results fit, got %q", *resp.NextCursor)
+	}
+}
+
+func TestClicks_DefaultLimit(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-limit@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-dlimit", "https://example.com", user.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	// Insert 3 clicks.
+	for i := 0; i < 3; i++ {
+		err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+			LinkID: link.ID, UserID: "", IPHash: "h", UserAgent: "", Referrer: "",
+		})
+		if err != nil {
+			t.Fatalf("record click %d: %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Clicks     []json.RawMessage `json:"clicks"`
+		NextCursor *string           `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Default limit is 50, we only have 3 clicks so all should be returned.
+	if len(resp.Clicks) != 3 {
+		t.Errorf("len(clicks) = %d, want 3", len(resp.Clicks))
+	}
+	if resp.NextCursor != nil {
+		t.Errorf("next_cursor should be nil, got %q", *resp.NextCursor)
+	}
+}
+
+func TestClicks_CustomLimit(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-climit@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-climit", "https://example.com", user.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+			LinkID: link.ID, UserID: "", IPHash: "h", UserAgent: "", Referrer: "",
+		})
+		if err != nil {
+			t.Fatalf("record click %d: %v", i, err)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks?limit=2", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Clicks     []json.RawMessage `json:"clicks"`
+		NextCursor *string           `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Clicks) != 2 {
+		t.Errorf("len(clicks) = %d, want 2", len(resp.Clicks))
+	}
+}
+
+func TestClicks_NextCursor(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-cursor@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-cursor", "https://example.com", user.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	// Insert 3 clicks.
+	for i := 0; i < 3; i++ {
+		err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+			LinkID: link.ID, UserID: "", IPHash: "h", UserAgent: "", Referrer: "",
+		})
+		if err != nil {
+			t.Fatalf("record click %d: %v", i, err)
+		}
+	}
+
+	// Request with limit=2 should return next_cursor.
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks?limit=2", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Clicks     []json.RawMessage `json:"clicks"`
+		NextCursor *string           `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Clicks) != 2 {
+		t.Errorf("len(clicks) = %d, want 2", len(resp.Clicks))
+	}
+	if resp.NextCursor == nil {
+		t.Fatal("next_cursor should be present when more results exist")
+	}
+
+	// Paginate with the cursor — should return the remaining click(s) with no next_cursor.
+	req2 := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks?limit=2&before="+*resp.NextCursor, nil)
+	authRequest(req2, token)
+	rec2 := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("page 2 status = %d, want %d; body: %s", rec2.Code, http.StatusOK, rec2.Body.String())
+	}
+
+	var resp2 struct {
+		Clicks     []json.RawMessage `json:"clicks"`
+		NextCursor *string           `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if len(resp2.Clicks) != 1 {
+		t.Errorf("page 2 len(clicks) = %d, want 1", len(resp2.Clicks))
+	}
+	if resp2.NextCursor != nil {
+		t.Errorf("page 2 next_cursor should be nil on last page, got %q", *resp2.NextCursor)
+	}
+}
+
+func TestClicks_InvalidBefore_BadRequest(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-bad-before@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-bad-before", "https://example.com", user.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks?before=not-a-timestamp", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestClicks_AnonymousClick_UserNull(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-anon@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-anon", "https://example.com", user.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	// Record an anonymous click (no user ID).
+	err = env.ClickStore.RecordClick(ctx, store.ClickEvent{
+		LinkID: link.ID, UserID: "", IPHash: "anon", UserAgent: "", Referrer: "",
+	})
+	if err != nil {
+		t.Fatalf("record click: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		Clicks []struct {
+			User *struct {
+				ID string `json:"id"`
+			} `json:"user"`
+			Referrer *string `json:"referrer"`
+		} `json:"clicks"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Clicks) != 1 {
+		t.Fatalf("len(clicks) = %d, want 1", len(resp.Clicks))
+	}
+	if resp.Clicks[0].User != nil {
+		t.Error("user should be null for anonymous click")
+	}
+	if resp.Clicks[0].Referrer != nil {
+		t.Error("referrer should be null when empty")
+	}
+}
+
+func TestClicks_NonOwner_Forbidden(t *testing.T) {
+	env := newTestEnv(t)
+	owner := seedUser(t, env, "clicks-own@example.com", "user")
+	other := seedUser(t, env, "clicks-oth@example.com", "user")
+	otherToken := seedToken(t, env, other.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "clicks-forbidden", "https://example.com", owner.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/links/"+link.ID+"/clicks", nil)
+	authRequest(req, otherToken)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestClicks_Unauthenticated(t *testing.T) {
+	env := newTestEnv(t)
+
+	req := httptest.NewRequest("GET", "/links/some-id/clicks", nil)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestClicks_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "clicks-nf@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	req := httptest.NewRequest("GET", "/links/nonexistent-id/clicks", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -19,6 +19,7 @@ type testEnv struct {
 	OwnershipStore *store.OwnershipStore
 	UserStore      *store.UserStore
 	TokenStore     *auth.SQLTokenStore
+	ClickStore     *store.ClickStore
 }
 
 // newTestEnv creates an in-memory SQLite test database, runs migrations,
@@ -32,6 +33,7 @@ func newTestEnv(t *testing.T) *testEnv {
 	ls := store.NewLinkStore(db, owns, tags)
 	us := store.NewUserStore(db)
 	ts := auth.NewSQLTokenStore(db)
+	cs := store.NewClickStore(db)
 
 	bearerMW := auth.NewBearerTokenMiddleware(ts, us)
 
@@ -42,6 +44,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		OwnershipStore:   owns,
 		TagStore:         tags,
 		UserStore:        us,
+		ClickStore:       cs,
 	}
 
 	router := api.NewAPIRouter(deps)
@@ -52,6 +55,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		OwnershipStore: owns,
 		UserStore:      us,
 		TokenStore:     ts,
+		ClickStore:     cs,
 	}
 }
 

--- a/internal/store/click_store_test.go
+++ b/internal/store/click_store_test.go
@@ -1,0 +1,496 @@
+// Governing: SPEC-0016 REQ "Click Data Schema", SPEC-0016 REQ "Click Recording"
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joestump/joe-links/internal/store"
+	"github.com/joestump/joe-links/internal/testutil"
+)
+
+// newClickTestEnv creates a test DB with a user, link, and click store.
+func newClickTestEnv(t *testing.T) (*store.ClickStore, *store.LinkStore, *store.UserStore, string, string) {
+	t.Helper()
+	db := testutil.NewTestDB(t)
+
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+
+	ctx := context.Background()
+	u, err := us.Upsert(ctx, "test", "sub1", "click-test@example.com", "Click Tester", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	link, err := ls.Create(ctx, "click-link", "https://example.com", u.ID, "Test Link", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	return cs, ls, us, u.ID, link.ID
+}
+
+func TestRecordClick_HappyPath(t *testing.T) {
+	cs, _, _, userID, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID:    linkID,
+		UserID:    userID,
+		IPHash:    "abc123",
+		UserAgent: "TestBrowser/1.0",
+		Referrer:  "https://referrer.com",
+	})
+	if err != nil {
+		t.Fatalf("RecordClick: %v", err)
+	}
+
+	stats, err := cs.GetClickStats(ctx, linkID)
+	if err != nil {
+		t.Fatalf("GetClickStats: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Errorf("total = %d, want 1", stats.Total)
+	}
+}
+
+func TestRecordClick_Anonymous(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID:    linkID,
+		UserID:    "", // anonymous
+		IPHash:    "anon-hash",
+		UserAgent: "Bot/1.0",
+		Referrer:  "",
+	})
+	if err != nil {
+		t.Fatalf("RecordClick anonymous: %v", err)
+	}
+
+	clicks, err := cs.ListRecentClicks(ctx, linkID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 1 {
+		t.Fatalf("len(clicks) = %d, want 1", len(clicks))
+	}
+	if clicks[0].UserID != "" {
+		t.Errorf("user_id = %q, want empty for anonymous click", clicks[0].UserID)
+	}
+	if clicks[0].DisplayName != "" {
+		t.Errorf("display_name = %q, want empty for anonymous click", clicks[0].DisplayName)
+	}
+}
+
+func TestRecordClick_Authenticated(t *testing.T) {
+	cs, _, _, userID, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID:    linkID,
+		UserID:    userID,
+		IPHash:    "auth-hash",
+		UserAgent: "Chrome/100",
+		Referrer:  "",
+	})
+	if err != nil {
+		t.Fatalf("RecordClick authenticated: %v", err)
+	}
+
+	clicks, err := cs.ListRecentClicks(ctx, linkID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 1 {
+		t.Fatalf("len(clicks) = %d, want 1", len(clicks))
+	}
+	if clicks[0].UserID != userID {
+		t.Errorf("user_id = %q, want %q", clicks[0].UserID, userID)
+	}
+	if clicks[0].DisplayName != "Click Tester" {
+		t.Errorf("display_name = %q, want %q", clicks[0].DisplayName, "Click Tester")
+	}
+}
+
+func TestRecordClick_UserAgentTruncated(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	longUA := strings.Repeat("A", 600)
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID:    linkID,
+		UserID:    "",
+		IPHash:    "ua-hash",
+		UserAgent: longUA,
+		Referrer:  "",
+	})
+	if err != nil {
+		t.Fatalf("RecordClick with long UA: %v", err)
+	}
+
+	// Verify it succeeded (truncation is internal; we just confirm no error and row exists).
+	stats, err := cs.GetClickStats(ctx, linkID)
+	if err != nil {
+		t.Fatalf("GetClickStats: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Errorf("total = %d, want 1", stats.Total)
+	}
+}
+
+func TestRecordClick_ReferrerTruncated(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	longRef := "https://example.com/" + strings.Repeat("x", 2100)
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID:    linkID,
+		UserID:    "",
+		IPHash:    "ref-hash",
+		UserAgent: "Bot/1.0",
+		Referrer:  longRef,
+	})
+	if err != nil {
+		t.Fatalf("RecordClick with long referrer: %v", err)
+	}
+
+	stats, err := cs.GetClickStats(ctx, linkID)
+	if err != nil {
+		t.Fatalf("GetClickStats: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Errorf("total = %d, want 1", stats.Total)
+	}
+}
+
+func TestGetClickStats_NoClicks(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	stats, err := cs.GetClickStats(ctx, linkID)
+	if err != nil {
+		t.Fatalf("GetClickStats: %v", err)
+	}
+	if stats.Total != 0 {
+		t.Errorf("total = %d, want 0", stats.Total)
+	}
+	if stats.Last7d != 0 {
+		t.Errorf("last_7d = %d, want 0", stats.Last7d)
+	}
+	if stats.Last30d != 0 {
+		t.Errorf("last_30d = %d, want 0", stats.Last30d)
+	}
+}
+
+func TestGetClickStats_NonExistentLink(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	stats, err := cs.GetClickStats(ctx, "nonexistent-link-id")
+	if err != nil {
+		t.Fatalf("GetClickStats for nonexistent link: %v", err)
+	}
+	if stats.Total != 0 {
+		t.Errorf("total = %d, want 0", stats.Total)
+	}
+	if stats.Last7d != 0 {
+		t.Errorf("last_7d = %d, want 0", stats.Last7d)
+	}
+	if stats.Last30d != 0 {
+		t.Errorf("last_30d = %d, want 0", stats.Last30d)
+	}
+}
+
+func TestGetClickStats_TimeWindows(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub-tw", "tw@example.com", "TW User", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "tw-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	now := time.Now().UTC()
+
+	// Insert clicks at specific times using raw SQL:
+	// 1 click: 2 days ago (within 7d and 30d)
+	// 1 click: 10 days ago (within 30d but not 7d)
+	// 1 click: 60 days ago (outside both windows)
+	times := []time.Time{
+		now.AddDate(0, 0, -2),  // within 7d
+		now.AddDate(0, 0, -10), // within 30d only
+		now.AddDate(0, 0, -60), // outside both
+	}
+
+	for i, ts := range times {
+		_, err := db.ExecContext(ctx,
+			db.Rebind(`INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at) VALUES (?, ?, NULL, ?, '', '', ?)`),
+			"click-tw-"+string(rune('a'+i)), link.ID, "hash", ts)
+		if err != nil {
+			t.Fatalf("insert click %d: %v", i, err)
+		}
+	}
+
+	stats, err := cs.GetClickStats(ctx, link.ID)
+	if err != nil {
+		t.Fatalf("GetClickStats: %v", err)
+	}
+	if stats.Total != 3 {
+		t.Errorf("total = %d, want 3", stats.Total)
+	}
+	if stats.Last7d != 1 {
+		t.Errorf("last_7d = %d, want 1", stats.Last7d)
+	}
+	if stats.Last30d != 2 {
+		t.Errorf("last_30d = %d, want 2", stats.Last30d)
+	}
+}
+
+func TestListRecentClicks_NewestFirst(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub-nf", "nf@example.com", "NF User", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "nf-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	now := time.Now().UTC()
+	// Insert 3 clicks at different times.
+	for i := 0; i < 3; i++ {
+		ts := now.Add(time.Duration(-i) * time.Hour)
+		_, err := db.ExecContext(ctx,
+			db.Rebind(`INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at) VALUES (?, ?, NULL, ?, '', '', ?)`),
+			"click-nf-"+string(rune('a'+i)), link.ID, "hash", ts)
+		if err != nil {
+			t.Fatalf("insert click %d: %v", i, err)
+		}
+	}
+
+	clicks, err := cs.ListRecentClicks(ctx, link.ID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 3 {
+		t.Fatalf("len = %d, want 3", len(clicks))
+	}
+	// Newest first: click-nf-a (now) > click-nf-b (now-1h) > click-nf-c (now-2h)
+	if !clicks[0].ClickedAt.After(clicks[1].ClickedAt) {
+		t.Errorf("clicks not in newest-first order: %v <= %v", clicks[0].ClickedAt, clicks[1].ClickedAt)
+	}
+	if !clicks[1].ClickedAt.After(clicks[2].ClickedAt) {
+		t.Errorf("clicks not in newest-first order: %v <= %v", clicks[1].ClickedAt, clicks[2].ClickedAt)
+	}
+}
+
+func TestListRecentClicks_RespectsLimit(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub-lim", "lim@example.com", "Lim User", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "lim-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		ts := now.Add(time.Duration(-i) * time.Minute)
+		_, err := db.ExecContext(ctx,
+			db.Rebind(`INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at) VALUES (?, ?, NULL, ?, '', '', ?)`),
+			"click-lim-"+string(rune('a'+i)), link.ID, "hash", ts)
+		if err != nil {
+			t.Fatalf("insert click %d: %v", i, err)
+		}
+	}
+
+	clicks, err := cs.ListRecentClicks(ctx, link.ID, 2)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 2 {
+		t.Errorf("len = %d, want 2", len(clicks))
+	}
+}
+
+func TestListRecentClicks_JoinsUserDisplayName(t *testing.T) {
+	cs, _, _, userID, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	err := cs.RecordClick(ctx, store.ClickEvent{
+		LinkID: linkID, UserID: userID, IPHash: "h1", UserAgent: "", Referrer: "",
+	})
+	if err != nil {
+		t.Fatalf("RecordClick: %v", err)
+	}
+
+	clicks, err := cs.ListRecentClicks(ctx, linkID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 1 {
+		t.Fatalf("len = %d, want 1", len(clicks))
+	}
+	if clicks[0].DisplayName != "Click Tester" {
+		t.Errorf("display_name = %q, want %q", clicks[0].DisplayName, "Click Tester")
+	}
+}
+
+func TestListRecentClicks_EmptyForNewLink(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	clicks, err := cs.ListRecentClicks(ctx, linkID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicks: %v", err)
+	}
+	if len(clicks) != 0 {
+		t.Errorf("len = %d, want 0", len(clicks))
+	}
+}
+
+func TestListRecentClicksBefore_ZeroBefore(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub-zb", "zb@example.com", "ZB User", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "zb-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		ts := now.Add(time.Duration(-i) * time.Minute)
+		_, err := db.ExecContext(ctx,
+			db.Rebind(`INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at) VALUES (?, ?, NULL, ?, '', '', ?)`),
+			"click-zb-"+string(rune('a'+i)), link.ID, "hash", ts)
+		if err != nil {
+			t.Fatalf("insert click %d: %v", i, err)
+		}
+	}
+
+	// Zero time => return from most recent.
+	clicks, err := cs.ListRecentClicksBefore(ctx, link.ID, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicksBefore: %v", err)
+	}
+	if len(clicks) != 3 {
+		t.Errorf("len = %d, want 3", len(clicks))
+	}
+}
+
+func TestListRecentClicksBefore_CursorFilters(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	cs := store.NewClickStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub-cf", "cf@example.com", "CF User", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "cf-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	now := time.Now().UTC()
+	// Insert 3 clicks with distinct timestamps.
+	t1 := now.Add(-3 * time.Hour)
+	t2 := now.Add(-2 * time.Hour)
+	t3 := now.Add(-1 * time.Hour)
+
+	for i, ts := range []time.Time{t1, t2, t3} {
+		_, err := db.ExecContext(ctx,
+			db.Rebind(`INSERT INTO link_clicks (id, link_id, user_id, ip_hash, user_agent, referrer, clicked_at) VALUES (?, ?, NULL, ?, '', '', ?)`),
+			"click-cf-"+string(rune('a'+i)), link.ID, "hash", ts)
+		if err != nil {
+			t.Fatalf("insert click %d: %v", i, err)
+		}
+	}
+
+	// Query with before = t3 should return only t2 and t1.
+	clicks, err := cs.ListRecentClicksBefore(ctx, link.ID, t3, 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicksBefore: %v", err)
+	}
+	if len(clicks) != 2 {
+		t.Fatalf("len = %d, want 2", len(clicks))
+	}
+}
+
+func TestListRecentClicksBefore_EmptyResult(t *testing.T) {
+	cs, _, _, _, linkID := newClickTestEnv(t)
+	ctx := context.Background()
+
+	clicks, err := cs.ListRecentClicksBefore(ctx, linkID, time.Now(), 10)
+	if err != nil {
+		t.Fatalf("ListRecentClicksBefore: %v", err)
+	}
+	if len(clicks) != 0 {
+		t.Errorf("len = %d, want 0", len(clicks))
+	}
+}
+
+func TestHashIP_SameIPSameDay(t *testing.T) {
+	h1 := store.HashIP("192.168.1.1")
+	h2 := store.HashIP("192.168.1.1")
+	if h1 != h2 {
+		t.Errorf("same IP produced different hashes: %q vs %q", h1, h2)
+	}
+}
+
+func TestHashIP_DifferentIPs(t *testing.T) {
+	h1 := store.HashIP("192.168.1.1")
+	h2 := store.HashIP("10.0.0.1")
+	if h1 == h2 {
+		t.Errorf("different IPs produced same hash: %q", h1)
+	}
+}


### PR DESCRIPTION
Closes #137 (partial)

## Summary
- Add `click_store_test.go` covering RecordClick (happy path, anonymous, authenticated, truncation), GetClickStats (empty, nonexistent, time windows), ListRecentClicks (ordering, limit, user join, empty), ListRecentClicksBefore (zero cursor, cursor filtering, empty result), and HashIP (same-day determinism, uniqueness)
- Wire ClickStore into API test env (`testutil_test.go`)
- Add `stats_test.go` covering `GET /api/v1/links/{id}/stats` (owner 200, non-owner 403, unauth 401, not found 404) and `GET /api/v1/links/{id}/clicks` (JSON structure, default limit, custom limit, next_cursor pagination, invalid before 400, anonymous user null, non-owner 403, unauth 401, not found 404)

## Test plan
- [x] `go test ./internal/store/... ./internal/api/... -count=1` passes

Governing: SPEC-0016 REQ "Click Data Schema", SPEC-0016 REQ "REST API Stats Endpoint", SPEC-0016 REQ "REST API Clicks Endpoint"