### PR TITLE
Rename /design: namespace to /sdd:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,12 @@ Third-party integrations live under `integrations/` to avoid polluting the repo 
 - `integrations/extension/` — Manifest V3 browser extension (Chrome, Firefox)
 - `integrations/apple/` — Safari Web Extension Xcode project (iOS 15+, macOS 12+); future Apple-platform apps go here too
 
-## Design Plugin Skills
+## SDD Skills
 
 | Skill | Purpose |
 |-------|---------|
-| `/design:adr` | Create a new Architecture Decision Record |
-| `/design:spec` | Create a new specification |
-| `/design:check` | Quick-check code against ADRs and specs for drift |
-| `/design:audit` | Comprehensive design artifact alignment audit |
-| `/design:prime` | Load architecture context into session |
+| `/sdd:adr` | Create a new Architecture Decision Record |
+| `/sdd:spec` | Create a new specification |
+| `/sdd:check` | Quick-check code against ADRs and specs for drift |
+| `/sdd:audit` | Comprehensive design artifact alignment audit |
+| `/sdd:prime` | Load architecture context into session |


### PR DESCRIPTION
## Summary

Mechanical CLAUDE.md sweep updating references from the old `/design:` plugin namespace to `/sdd:` (Spec-Driven Development). The plugin was renamed in joestump/claude-plugin-sdd#75 because Anthropic shipped an official `design` plugin that collides with the namespace.

Doc-only changes:
- `/design:*` → `/sdd:*`
- `claude-plugin-design` → `claude-plugin-sdd`
- "design plugin" → "SDD plugin"
- `### Design Plugin Skills` → `### SDD Skills`

## Test plan

- [x] `git diff` reviewed — only CLAUDE.md namespace strings changed
- [ ] Run `/sdd:prime` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)