### PR TITLE
Enforce title/description length limits (SPEC-0002)

### DIFF
--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -143,6 +143,12 @@ func (h *linksAPIHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Governing: SPEC-0002 REQ "Links Table" — title max 200, description max 2000 characters
+	if err := store.ValidateLinkText(req.Title, req.Description); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error(), "INVALID_FIELD_LENGTH")
+		return
+	}
+
 	// Governing: SPEC-0010 REQ "REST API Visibility Field" — defaults to "public"
 	visibility := req.Visibility
 	if visibility == "" {
@@ -312,6 +318,12 @@ func (h *linksAPIHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
 	if err := store.ValidateURLVariables(req.URL); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error(), "INVALID_URL")
+		return
+	}
+
+	// Governing: SPEC-0002 REQ "Links Table" — title max 200, description max 2000 characters
+	if err := store.ValidateLinkText(req.Title, req.Description); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error(), "INVALID_FIELD_LENGTH")
 		return
 	}
 

--- a/internal/handler/links.go
+++ b/internal/handler/links.go
@@ -42,11 +42,11 @@ type LinkForm struct {
 // LinkFormPage is the template data for the new/edit link forms.
 type LinkFormPage struct {
 	BasePage
-	User    *store.User
-	Link    *store.Link
-	Form    LinkForm
-	Error   string
-	Flash   *Flash
+	User  *store.User
+	Link  *store.Link
+	Form  LinkForm
+	Error string
+	Flash *Flash
 }
 
 // LinkDetailPage is the template data for the link detail view.
@@ -162,6 +162,17 @@ func (h *LinksHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
 	if err := store.ValidateURLVariables(form.URL); err != nil {
+		data := LinkFormPage{BasePage: newBasePage(r, user), User: user, Form: form, Error: err.Error()}
+		if isHTMX(r) {
+			renderFragment(w, "new_link_modal", data)
+			return
+		}
+		render(w, "new.html", data)
+		return
+	}
+
+	// Governing: SPEC-0002 REQ "Links Table" — title max 200, description max 2000 characters
+	if err := store.ValidateLinkText(form.Title, form.Description); err != nil {
 		data := LinkFormPage{BasePage: newBasePage(r, user), User: user, Form: form, Error: err.Error()}
 		if isHTMX(r) {
 			renderFragment(w, "new_link_modal", data)
@@ -294,6 +305,17 @@ func (h *LinksHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	// Governing: SPEC-0009 REQ "Variable Placeholder Syntax", ADR-0013
 	if err := store.ValidateURLVariables(form.URL); err != nil {
+		data := LinkFormPage{BasePage: newBasePage(r, user), User: user, Link: link, Form: form, Error: err.Error()}
+		if isHTMX(r) {
+			renderFragment(w, "edit_link_modal", data)
+			return
+		}
+		render(w, "edit.html", data)
+		return
+	}
+
+	// Governing: SPEC-0002 REQ "Links Table" — title max 200, description max 2000 characters
+	if err := store.ValidateLinkText(form.Title, form.Description); err != nil {
 		data := LinkFormPage{BasePage: newBasePage(r, user), User: user, Link: link, Form: form, Error: err.Error()}
 		if isHTMX(r) {
 			renderFragment(w, "edit_link_modal", data)

--- a/internal/store/link_store.go
+++ b/internal/store/link_store.go
@@ -36,9 +36,9 @@ type ShareRecord struct {
 // LinkStore is the sqlx-backed implementation of LinkStoreIface.
 // Governing: SPEC-0002 REQ "Link Store Interface"
 type LinkStore struct {
-	db    *sqlx.DB
-	owns  *OwnershipStore
-	tags  *TagStore
+	db   *sqlx.DB
+	owns *OwnershipStore
+	tags *TagStore
 }
 
 func NewLinkStore(db *sqlx.DB, owns *OwnershipStore, tags *TagStore) *LinkStore {
@@ -69,6 +69,10 @@ func (s *LinkStore) aggAll(col string) string {
 // Create inserts a new link and registers ownerID as the primary owner.
 // Governing: SPEC-0010 REQ "Visibility Selector in Link Forms"
 func (s *LinkStore) Create(ctx context.Context, slug, url, ownerID, title, description, visibility string) (*Link, error) {
+	// Governing: SPEC-0002 REQ "Links Table" — reject over-length title/description before insert
+	if err := ValidateLinkText(title, description); err != nil {
+		return nil, err
+	}
 	if visibility == "" {
 		visibility = "public"
 	}
@@ -223,6 +227,10 @@ func (s *LinkStore) ListByOwnerAndTag(ctx context.Context, ownerID, tagSlug stri
 // Governing: SPEC-0001 REQ "Short Link Management" — slug is immutable after creation.
 // Governing: SPEC-0010 REQ "Visibility Selector in Link Forms"
 func (s *LinkStore) Update(ctx context.Context, id, url, title, description, visibility string) (*Link, error) {
+	// Governing: SPEC-0002 REQ "Links Table" — reject over-length title/description before update
+	if err := ValidateLinkText(title, description); err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	_, err := s.db.ExecContext(ctx, s.q(`
 		UPDATE links SET url = ?, title = ?, description = ?, visibility = ?, updated_at = ? WHERE id = ?
@@ -258,7 +266,6 @@ func (s *LinkStore) ListByOwnerOrShared(ctx context.Context, userID string) ([]*
 	}
 	return links, nil
 }
-
 
 // ListByURL returns links whose URL exactly matches the given string.
 // Admins see all matches; regular users see owned, shared, or public links.

--- a/internal/store/validate.go
+++ b/internal/store/validate.go
@@ -5,11 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"unicode/utf8"
+)
+
+// Link text length limits.
+// Governing: SPEC-0002 REQ "Links Table" — title max 200, description max 2000 characters
+const (
+	MaxTitleLength       = 200
+	MaxDescriptionLength = 2000
 )
 
 var (
 	// ErrSlugInvalid is returned when a slug does not match the required pattern.
 	ErrSlugInvalid = errors.New("slug must match [a-z0-9][a-z0-9-]*[a-z0-9]")
+
+	// ErrTitleTooLong is returned when a title exceeds MaxTitleLength characters.
+	// Governing: SPEC-0002 REQ "Links Table" scenario "Title Exceeds Maximum Length"
+	ErrTitleTooLong = fmt.Errorf("title must be at most %d characters", MaxTitleLength)
+
+	// ErrDescriptionTooLong is returned when a description exceeds MaxDescriptionLength characters.
+	// Governing: SPEC-0002 REQ "Links Table" scenario "Description Exceeds Maximum Length"
+	ErrDescriptionTooLong = fmt.Errorf("description must be at most %d characters", MaxDescriptionLength)
 
 	// ErrSlugReserved is returned when a slug matches a reserved route prefix.
 	ErrSlugReserved = errors.New("slug is reserved and cannot be used")
@@ -52,6 +68,20 @@ func ValidateSlugFormat(slug string) error {
 	}
 	if reservedSlugs[slug] {
 		return fmt.Errorf("%w: %q", ErrSlugReserved, slug)
+	}
+	return nil
+}
+
+// ValidateLinkText checks that title and description do not exceed their
+// maximum character lengths. Length is measured in Unicode code points (runes),
+// matching the spec's "characters" wording.
+// Governing: SPEC-0002 REQ "Links Table" scenarios "Title/Description Exceeds Maximum Length"
+func ValidateLinkText(title, description string) error {
+	if utf8.RuneCountInString(title) > MaxTitleLength {
+		return ErrTitleTooLong
+	}
+	if utf8.RuneCountInString(description) > MaxDescriptionLength {
+		return ErrDescriptionTooLong
 	}
 	return nil
 }

--- a/internal/store/validate_test.go
+++ b/internal/store/validate_test.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -111,6 +112,41 @@ func TestValidateURLVariables(t *testing.T) {
 			}
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("ValidateURLVariables(%q) = %v, want error wrapping %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Governing: SPEC-0002 REQ "Links Table" scenarios "Title/Description Exceeds Maximum Length"
+func TestValidateLinkText(t *testing.T) {
+	tests := []struct {
+		name        string
+		title       string
+		description string
+		wantErr     error
+	}{
+		{name: "both empty", title: "", description: "", wantErr: nil},
+		{name: "short values", title: "Docs", description: "The team docs", wantErr: nil},
+		{name: "title at limit", title: strings.Repeat("a", MaxTitleLength), description: "", wantErr: nil},
+		{name: "description at limit", title: "", description: strings.Repeat("b", MaxDescriptionLength), wantErr: nil},
+		{name: "title over limit", title: strings.Repeat("a", MaxTitleLength+1), description: "", wantErr: ErrTitleTooLong},
+		{name: "description over limit", title: "", description: strings.Repeat("b", MaxDescriptionLength+1), wantErr: ErrDescriptionTooLong},
+		// Length is counted in runes, not bytes: 200 multi-byte chars are valid.
+		{name: "multibyte title at limit", title: strings.Repeat("é", MaxTitleLength), description: "", wantErr: nil},
+		{name: "multibyte title over limit", title: strings.Repeat("é", MaxTitleLength+1), description: "", wantErr: ErrTitleTooLong},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLinkText(tt.title, tt.description)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("ValidateLinkText(...) = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidateLinkText(...) = %v, want %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Closes #166 (CRITICAL — Code vs Spec drift from the 2026-06 design audit).

SPEC-0002 REQ "Links Table" mandates `title` ≤ 200 and `description` ≤ 2000 characters, with scenarios requiring a validation error and **no insert** when exceeded. No length validation existed, so oversized values were persisted.

## Changes
- `internal/store/validate.go`: `MaxTitleLength`/`MaxDescriptionLength` consts, `ErrTitleTooLong`/`ErrDescriptionTooLong`, and `ValidateLinkText` (counts Unicode runes to match "characters").
- `internal/store/link_store.go`: `LinkStore.Create` and `LinkStore.Update` call `ValidateLinkText` first — guarantees no caller can insert/update over-length text.
- `internal/api/links.go`: explicit 400 (`INVALID_FIELD_LENGTH`) on Create/Update.
- `internal/handler/links.go`: inline modal error on the HTMX create/edit forms.
- `internal/store/validate_test.go`: table-driven tests (boundary + multi-byte).

## Testing
- `go build ./...` clean
- `go test ./...` green (new `TestValidateLinkText` + existing suite)

Governing: SPEC-0002 REQ "Links Table" scenarios "Title/Description Exceeds Maximum Length", ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)