### PR TITLE
Cursor-based pagination on REST list endpoints (SPEC-0005)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -33,6 +33,20 @@ const docTemplate = `{
                     "Admin"
                 ],
                 "summary": "List all links (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -79,6 +93,20 @@ const docTemplate = `{
                     "Admin"
                 ],
                 "summary": "List all users (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -201,6 +229,20 @@ const docTemplate = `{
                     "Links"
                 ],
                 "summary": "List links",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -980,6 +1022,20 @@ const docTemplate = `{
                     "Tags"
                 ],
                 "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -26,6 +26,20 @@
                     "Admin"
                 ],
                 "summary": "List all links (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -72,6 +86,20 @@
                     "Admin"
                 ],
                 "summary": "List all users (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -194,6 +222,20 @@
                     "Links"
                 ],
                 "summary": "List links",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -973,6 +1015,20 @@
                     "Tags"
                 ],
                 "summary": "List tags",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items to return (default 50, max 200)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a prior next_cursor",
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -230,6 +230,15 @@ paths:
       - application/json
       description: Returns all links system-wide with owners and tags. Requires admin
         role.
+      parameters:
+      - description: Max items to return (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor from a prior next_cursor
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:
@@ -259,6 +268,15 @@ paths:
       consumes:
       - application/json
       description: Returns all users in the system. Requires admin role.
+      parameters:
+      - description: Max items to return (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor from a prior next_cursor
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:
@@ -338,6 +356,15 @@ paths:
       consumes:
       - application/json
       description: Returns links owned by the caller. Admins see all links.
+      parameters:
+      - description: Max items to return (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor from a prior next_cursor
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:
@@ -845,6 +872,15 @@ paths:
       consumes:
       - application/json
       description: Returns all tags that have at least one associated link.
+      parameters:
+      - description: Max items to return (default 50, max 200)
+        in: query
+        name: limit
+        type: integer
+      - description: Opaque pagination cursor from a prior next_cursor
+        in: query
+        name: cursor
+        type: string
       produces:
       - application/json
       responses:

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -61,6 +61,8 @@ func requireAdmin(next http.Handler) http.Handler {
 // @Tags         Admin
 // @Accept       json
 // @Produce      json
+// @Param        limit   query     int     false  "Max items to return (default 50, max 200)"
+// @Param        cursor  query     string  false  "Opaque pagination cursor from a prior next_cursor"
 // @Success      200  {object}  UserListResponse
 // @Failure      401  {object}  ErrorResponse
 // @Failure      403  {object}  ErrorResponse
@@ -68,13 +70,26 @@ func requireAdmin(next http.Handler) http.Handler {
 // @Security     BearerToken
 // @Router       /admin/users [get]
 func (h *adminAPIHandler) ListUsers(w http.ResponseWriter, r *http.Request) {
-	users, err := h.users.ListAll(r.Context())
+	// Governing: SPEC-0005 REQ "Pagination" — ?limit (default 50, max 200) + opaque ?cursor
+	limit := parseLimit(r)
+	cursorName, cursorID := parseCursor(r)
+
+	// Fetch limit+1 to detect whether another page exists.
+	users, err := h.users.ListAllPaginated(r.Context(), limit+1, cursorName, cursorID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
 		return
 	}
 
-	resp := &UserListResponse{Users: make([]*UserResponse, 0, len(users))}
+	var nextCursor *string
+	if len(users) > limit {
+		last := users[limit-1]
+		c := encodeCursor(last.DisplayName, last.ID)
+		nextCursor = &c
+		users = users[:limit]
+	}
+
+	resp := &UserListResponse{Users: make([]*UserResponse, 0, len(users)), NextCursor: nextCursor}
 	for _, u := range users {
 		resp.Users = append(resp.Users, &UserResponse{
 			ID:          u.ID,
@@ -149,6 +164,8 @@ func (h *adminAPIHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 // @Tags         Admin
 // @Accept       json
 // @Produce      json
+// @Param        limit   query     int     false  "Max items to return (default 50, max 200)"
+// @Param        cursor  query     string  false  "Opaque pagination cursor from a prior next_cursor"
 // @Success      200  {object}  LinkListResponse
 // @Failure      401  {object}  ErrorResponse
 // @Failure      403  {object}  ErrorResponse
@@ -156,13 +173,26 @@ func (h *adminAPIHandler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 // @Security     BearerToken
 // @Router       /admin/links [get]
 func (h *adminAPIHandler) ListLinks(w http.ResponseWriter, r *http.Request) {
-	links, err := h.links.ListAll(r.Context())
+	// Governing: SPEC-0005 REQ "Pagination" — ?limit (default 50, max 200) + opaque ?cursor
+	limit := parseLimit(r)
+	cursorSlug, cursorID := parseCursor(r)
+
+	// Fetch limit+1 to detect whether another page exists.
+	links, err := h.links.ListAllPaginated(r.Context(), limit+1, cursorSlug, cursorID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
 		return
 	}
 
-	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links))}
+	var nextCursor *string
+	if len(links) > limit {
+		last := links[limit-1]
+		c := encodeCursor(last.Slug, last.ID)
+		nextCursor = &c
+		links = links[:limit]
+	}
+
+	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links)), NextCursor: nextCursor}
 	for _, l := range links {
 		// Build owner list for each link.
 		owners, err := h.ownership.ListOwnerUsers(l.ID)

--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -46,6 +46,8 @@ func registerLinkRoutes(r chi.Router, links *store.LinkStore, ownership *store.O
 // @Tags         Links
 // @Accept       json
 // @Produce      json
+// @Param        limit   query     int     false  "Max items to return (default 50, max 200)"
+// @Param        cursor  query     string  false  "Opaque pagination cursor from a prior next_cursor"
 // @Success      200  {object}  LinkListResponse
 // @Failure      401  {object}  ErrorResponse
 // @Failure      500  {object}  ErrorResponse
@@ -58,23 +60,54 @@ func (h *linksAPIHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var links []*store.Link
-	var err error
+	// Governing: SPEC-0005 REQ "Pagination" — ?limit (default 50, max 200) + opaque ?cursor
+	limit := parseLimit(r)
+	cursorSlug, cursorID := parseCursor(r)
 
+	// The ?url= filter is an exact-match lookup that returns a bounded set; it is
+	// served unpaginated (next_cursor stays null).
 	// Governing: SPEC-0010 REQ "REST API Visibility Field" — non-admin sees owned + shared
 	if urlFilter := r.URL.Query().Get("url"); urlFilter != "" {
-		links, err = h.links.ListByURL(r.Context(), urlFilter, user.ID, user.Role == "admin")
-	} else if user.Role == "admin" {
-		links, err = h.links.ListAll(r.Context())
+		links, err := h.links.ListByURL(r.Context(), urlFilter, user.ID, user.Role == "admin")
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+			return
+		}
+		resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links))}
+		for _, l := range links {
+			lr, err := h.toLinkResponse(r.Context(), l)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
+				return
+			}
+			resp.Links = append(resp.Links, lr)
+		}
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	// Fetch limit+1 to detect whether another page exists.
+	var links []*store.Link
+	var err error
+	if user.Role == "admin" {
+		links, err = h.links.ListAllPaginated(r.Context(), limit+1, cursorSlug, cursorID)
 	} else {
-		links, err = h.links.ListByOwnerOrShared(r.Context(), user.ID)
+		links, err = h.links.ListByOwnerOrSharedPaginated(r.Context(), user.ID, limit+1, cursorSlug, cursorID)
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error", "INTERNAL_ERROR")
 		return
 	}
 
-	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links))}
+	var nextCursor *string
+	if len(links) > limit {
+		last := links[limit-1]
+		c := encodeCursor(last.Slug, last.ID)
+		nextCursor = &c
+		links = links[:limit]
+	}
+
+	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links)), NextCursor: nextCursor}
 	for _, l := range links {
 		lr, err := h.toLinkResponse(r.Context(), l)
 		if err != nil {

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -1,0 +1,64 @@
+// Governing: SPEC-0005 REQ "Pagination", ADR-0008
+package api
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Pagination defaults per SPEC-0005 REQ "Pagination".
+const (
+	defaultPageLimit = 50
+	maxPageLimit     = 200
+)
+
+// parseLimit reads ?limit=N (default 50, max 200). Invalid, zero, or negative
+// values fall back to the default; values above the max are silently capped.
+// Governing: SPEC-0005 REQ "Pagination" — Scenario Default Limit Applied, Scenario Limit Capped
+func parseLimit(r *http.Request) int {
+	limit := defaultPageLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxPageLimit {
+		limit = maxPageLimit
+	}
+	return limit
+}
+
+// parseCursor reads ?cursor= and decodes the opaque keyset cursor into its
+// (sortKey, id) components. Returns empty strings when no cursor is present or
+// the value is malformed (malformed cursors restart from the first page).
+// Governing: SPEC-0005 REQ "Pagination"
+func parseCursor(r *http.Request) (sortKey, id string) {
+	return decodeCursor(r.URL.Query().Get("cursor"))
+}
+
+// encodeCursor builds an opaque base64 cursor from a row's sort key and id.
+// The cursor encodes "sortKey\x00id" so keyset pagination has a deterministic
+// tiebreaker when multiple rows share the same sort key.
+// Governing: SPEC-0005 REQ "Pagination"
+func encodeCursor(sortKey, id string) string {
+	return base64.URLEncoding.EncodeToString([]byte(sortKey + "\x00" + id))
+}
+
+// decodeCursor reverses encodeCursor. Malformed input yields empty components.
+// Governing: SPEC-0005 REQ "Pagination"
+func decodeCursor(cursor string) (sortKey, id string) {
+	if cursor == "" {
+		return "", ""
+	}
+	raw, err := base64.URLEncoding.DecodeString(cursor)
+	if err != nil {
+		return "", ""
+	}
+	parts := strings.SplitN(string(raw), "\x00", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -1,0 +1,299 @@
+// Governing: SPEC-0005 REQ "Pagination"
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joestump/joe-links/internal/api"
+)
+
+// seedLinks creates n links owned by the user with zero-padded slugs so the
+// (slug, id) ordering is deterministic across pages.
+func seedLinks(t *testing.T, env *testEnv, userID string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		slug := fmt.Sprintf("link-%04d", i)
+		_, err := env.LinkStore.Create(context.Background(), slug, "https://example.com/"+slug, userID, "", "", "")
+		if err != nil {
+			t.Fatalf("seed link %s: %v", slug, err)
+		}
+	}
+}
+
+func TestLinks_List_DefaultLimit(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	seedLinks(t, env, user.ID, 60)
+
+	req := authRequest(httptest.NewRequest("GET", "/links", nil), token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp api.LinkListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Links) != 50 {
+		t.Errorf("len(links) = %d, want 50 (default limit)", len(resp.Links))
+	}
+	if resp.NextCursor == nil {
+		t.Errorf("next_cursor = nil, want non-nil (more results exist)")
+	}
+}
+
+func TestLinks_List_LimitCapped(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	seedLinks(t, env, user.ID, 250)
+
+	req := authRequest(httptest.NewRequest("GET", "/links?limit=999", nil), token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp api.LinkListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Links) != 200 {
+		t.Errorf("len(links) = %d, want 200 (capped)", len(resp.Links))
+	}
+}
+
+func TestLinks_List_InvalidLimitUsesDefault(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	seedLinks(t, env, user.ID, 60)
+
+	for _, q := range []string{"limit=abc", "limit=-5", "limit=0"} {
+		req := authRequest(httptest.NewRequest("GET", "/links?"+q, nil), token)
+		rec := httptest.NewRecorder()
+		env.Router.ServeHTTP(rec, req)
+
+		var resp api.LinkListResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("%s: decode: %v", q, err)
+		}
+		if len(resp.Links) != 50 {
+			t.Errorf("%s: len(links) = %d, want 50 (default)", q, len(resp.Links))
+		}
+	}
+}
+
+func TestLinks_List_CursorRoundTrip(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	const total = 130
+	seedLinks(t, env, user.ID, total)
+
+	seen := map[string]bool{}
+	cursor := ""
+	pages := 0
+	for {
+		url := "/links?limit=50"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		req := authRequest(httptest.NewRequest("GET", url, nil), token)
+		rec := httptest.NewRecorder()
+		env.Router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d: status = %d; body: %s", pages, rec.Code, rec.Body.String())
+		}
+		var resp api.LinkListResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("page %d: decode: %v", pages, err)
+		}
+		for _, l := range resp.Links {
+			if seen[l.ID] {
+				t.Fatalf("duplicate link %s across pages", l.Slug)
+			}
+			seen[l.ID] = true
+		}
+		pages++
+		if pages > 10 {
+			t.Fatalf("too many pages, possible infinite loop")
+		}
+		if resp.NextCursor == nil {
+			if len(resp.Links) > 50 {
+				t.Fatalf("last page had %d links, want <= 50", len(resp.Links))
+			}
+			break
+		}
+		cursor = *resp.NextCursor
+	}
+
+	if len(seen) != total {
+		t.Errorf("collected %d unique links across pages, want %d", len(seen), total)
+	}
+	if pages != 3 {
+		t.Errorf("pages = %d, want 3 (50+50+30)", pages)
+	}
+}
+
+func TestTags_List_Pagination(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	// Each link gets a distinct tag so every tag has link_count == 1.
+	for i := 0; i < 60; i++ {
+		slug := fmt.Sprintf("link-%04d", i)
+		link, err := env.LinkStore.Create(context.Background(), slug, "https://example.com/"+slug, user.ID, "", "", "")
+		if err != nil {
+			t.Fatalf("create link: %v", err)
+		}
+		if err := env.LinkStore.SetTags(context.Background(), link.ID, []string{fmt.Sprintf("tag-%04d", i)}); err != nil {
+			t.Fatalf("set tags: %v", err)
+		}
+	}
+
+	// Default limit.
+	req := authRequest(httptest.NewRequest("GET", "/tags", nil), token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp api.TagListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Tags) != 50 {
+		t.Errorf("len(tags) = %d, want 50", len(resp.Tags))
+	}
+	if resp.NextCursor == nil {
+		t.Fatalf("next_cursor = nil, want non-nil")
+	}
+
+	// Round-trip the cursor for the remaining 10.
+	req2 := authRequest(httptest.NewRequest("GET", "/tags?cursor="+*resp.NextCursor, nil), token)
+	rec2 := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec2, req2)
+	var resp2 api.TagListResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if len(resp2.Tags) != 10 {
+		t.Errorf("page 2 len(tags) = %d, want 10", len(resp2.Tags))
+	}
+	if resp2.NextCursor != nil {
+		t.Errorf("page 2 next_cursor = %v, want nil (last page)", *resp2.NextCursor)
+	}
+}
+
+func TestAdminUsers_List_Pagination(t *testing.T) {
+	env := newTestEnv(t)
+	admin := seedUser(t, env, "admin@example.com", "admin")
+	token := seedToken(t, env, admin.ID)
+
+	// admin is user #1; add 59 more for 60 total.
+	for i := 0; i < 59; i++ {
+		seedUser(t, env, fmt.Sprintf("user-%04d@example.com", i), "user")
+	}
+
+	req := authRequest(httptest.NewRequest("GET", "/admin/users?limit=999", nil), token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp api.UserListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// 60 users < 200 cap, so all returned and no next cursor.
+	if len(resp.Users) != 60 {
+		t.Errorf("len(users) = %d, want 60", len(resp.Users))
+	}
+	if resp.NextCursor != nil {
+		t.Errorf("next_cursor = %v, want nil", *resp.NextCursor)
+	}
+
+	// Now page with limit=25 and round-trip.
+	seen := map[string]bool{}
+	cursor := ""
+	pages := 0
+	for {
+		url := "/admin/users?limit=25"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+		r := authRequest(httptest.NewRequest("GET", url, nil), token)
+		w := httptest.NewRecorder()
+		env.Router.ServeHTTP(w, r)
+		var pr api.UserListResponse
+		if err := json.NewDecoder(w.Body).Decode(&pr); err != nil {
+			t.Fatalf("page %d decode: %v", pages, err)
+		}
+		for _, u := range pr.Users {
+			if seen[u.ID] {
+				t.Fatalf("duplicate user %s", u.Email)
+			}
+			seen[u.ID] = true
+		}
+		pages++
+		if pr.NextCursor == nil {
+			break
+		}
+		cursor = *pr.NextCursor
+		if pages > 10 {
+			t.Fatalf("infinite loop")
+		}
+	}
+	if len(seen) != 60 {
+		t.Errorf("collected %d users, want 60", len(seen))
+	}
+}
+
+func TestAdminLinks_List_Pagination(t *testing.T) {
+	env := newTestEnv(t)
+	admin := seedUser(t, env, "admin@example.com", "admin")
+	token := seedToken(t, env, admin.ID)
+	seedLinks(t, env, admin.ID, 60)
+
+	req := authRequest(httptest.NewRequest("GET", "/admin/links", nil), token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp api.LinkListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Links) != 50 {
+		t.Errorf("len(links) = %d, want 50", len(resp.Links))
+	}
+	if resp.NextCursor == nil {
+		t.Fatalf("next_cursor = nil, want non-nil")
+	}
+
+	req2 := authRequest(httptest.NewRequest("GET", "/admin/links?cursor="+*resp.NextCursor, nil), token)
+	rec2 := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec2, req2)
+	var resp2 api.LinkListResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode page 2: %v", err)
+	}
+	if len(resp2.Links) != 10 {
+		t.Errorf("page 2 len(links) = %d, want 10", len(resp2.Links))
+	}
+	if resp2.NextCursor != nil {
+		t.Errorf("page 2 next_cursor = %v, want nil", *resp2.NextCursor)
+	}
+}

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -34,6 +34,8 @@ func registerTagRoutes(r chi.Router, tags *store.TagStore, links *store.LinkStor
 // @Tags         Tags
 // @Accept       json
 // @Produce      json
+// @Param        limit   query     int     false  "Max items to return (default 50, max 200)"
+// @Param        cursor  query     string  false  "Opaque pagination cursor from a prior next_cursor"
 // @Success      200  {object}  TagListResponse
 // @Failure      401  {object}  ErrorResponse
 // @Failure      500  {object}  ErrorResponse
@@ -46,13 +48,26 @@ func (h *tagsAPIHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tagsWithCounts, err := h.tags.ListWithCounts(r.Context())
+	// Governing: SPEC-0005 REQ "Pagination" — ?limit (default 50, max 200) + opaque ?cursor
+	limit := parseLimit(r)
+	cursorName, cursorID := parseCursor(r)
+
+	// Fetch limit+1 to detect whether another page exists.
+	tagsWithCounts, err := h.tags.ListWithCountsPaginated(r.Context(), limit+1, cursorName, cursorID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal error", "internal_error")
 		return
 	}
 
-	resp := &TagListResponse{Tags: make([]*TagResponse, 0, len(tagsWithCounts))}
+	var nextCursor *string
+	if len(tagsWithCounts) > limit {
+		last := tagsWithCounts[limit-1]
+		c := encodeCursor(last.Name, last.ID)
+		nextCursor = &c
+		tagsWithCounts = tagsWithCounts[:limit]
+	}
+
+	resp := &TagListResponse{Tags: make([]*TagResponse, 0, len(tagsWithCounts)), NextCursor: nextCursor}
 	for _, t := range tagsWithCounts {
 		resp.Tags = append(resp.Tags, &TagResponse{
 			Slug:      t.Slug,

--- a/internal/store/link_store.go
+++ b/internal/store/link_store.go
@@ -163,6 +163,57 @@ func (s *LinkStore) ListAll(ctx context.Context) ([]*Link, error) {
 	return links, nil
 }
 
+// ListAllPaginated returns links ordered by (slug, id), starting after the
+// given keyset cursor. It fetches up to limit rows; pass cursorSlug/cursorID
+// from the last row of the previous page (empty for the first page).
+// Governing: SPEC-0005 REQ "Pagination"
+func (s *LinkStore) ListAllPaginated(ctx context.Context, limit int, cursorSlug, cursorID string) ([]*Link, error) {
+	var links []*Link
+	if cursorSlug == "" && cursorID == "" {
+		err := s.db.SelectContext(ctx, &links, s.q(`
+			SELECT * FROM links
+			ORDER BY slug ASC, id ASC
+			LIMIT ?
+		`), limit)
+		return links, err
+	}
+	err := s.db.SelectContext(ctx, &links, s.q(`
+		SELECT * FROM links
+		WHERE slug > ? OR (slug = ? AND id > ?)
+		ORDER BY slug ASC, id ASC
+		LIMIT ?
+	`), cursorSlug, cursorSlug, cursorID, limit)
+	return links, err
+}
+
+// ListByOwnerOrSharedPaginated returns links where userID is an owner or has a
+// share record, ordered by (slug, id) and keyset-paginated.
+// Governing: SPEC-0005 REQ "Pagination", SPEC-0010 REQ "REST API Visibility Field"
+func (s *LinkStore) ListByOwnerOrSharedPaginated(ctx context.Context, userID string, limit int, cursorSlug, cursorID string) ([]*Link, error) {
+	var links []*Link
+	if cursorSlug == "" && cursorID == "" {
+		err := s.db.SelectContext(ctx, &links, s.q(`
+			SELECT DISTINCT l.* FROM links l
+			LEFT JOIN link_owners lo ON lo.link_id = l.id AND lo.user_id = ?
+			LEFT JOIN link_shares ls ON ls.link_id = l.id AND ls.user_id = ?
+			WHERE lo.user_id IS NOT NULL OR ls.user_id IS NOT NULL
+			ORDER BY l.slug ASC, l.id ASC
+			LIMIT ?
+		`), userID, userID, limit)
+		return links, err
+	}
+	err := s.db.SelectContext(ctx, &links, s.q(`
+		SELECT DISTINCT l.* FROM links l
+		LEFT JOIN link_owners lo ON lo.link_id = l.id AND lo.user_id = ?
+		LEFT JOIN link_shares ls ON ls.link_id = l.id AND ls.user_id = ?
+		WHERE (lo.user_id IS NOT NULL OR ls.user_id IS NOT NULL)
+		  AND (l.slug > ? OR (l.slug = ? AND l.id > ?))
+		ORDER BY l.slug ASC, l.id ASC
+		LIMIT ?
+	`), userID, userID, cursorSlug, cursorSlug, cursorID, limit)
+	return links, err
+}
+
 // SearchByOwner returns links owned by userID whose slug, url, or description
 // contain the search term (case-insensitive LIKE). Returns all owner links if q is empty.
 // Governing: SPEC-0004 REQ "User Dashboard" — HTMX debounced search

--- a/internal/store/tag_store.go
+++ b/internal/store/tag_store.go
@@ -168,6 +168,37 @@ func (s *TagStore) ListWithCounts(ctx context.Context) ([]*TagWithCount, error) 
 	return tags, nil
 }
 
+// ListWithCountsPaginated returns tags with ≥1 link, annotated with their link
+// count, ordered by (name, id) and keyset-paginated. Pass cursorName/cursorID
+// from the last row of the previous page (empty for the first page).
+// Governing: SPEC-0005 REQ "Pagination", SPEC-0004 REQ "Tag Browser"
+func (s *TagStore) ListWithCountsPaginated(ctx context.Context, limit int, cursorName, cursorID string) ([]*TagWithCount, error) {
+	var tags []*TagWithCount
+	if cursorName == "" && cursorID == "" {
+		err := s.db.SelectContext(ctx, &tags, s.q(`
+			SELECT t.*, COUNT(lt.link_id) as link_count
+			FROM tags t
+			INNER JOIN link_tags lt ON lt.tag_id = t.id
+			GROUP BY t.id
+			HAVING COUNT(lt.link_id) >= 1
+			ORDER BY t.name ASC, t.id ASC
+			LIMIT ?
+		`), limit)
+		return tags, err
+	}
+	err := s.db.SelectContext(ctx, &tags, s.q(`
+		SELECT t.*, COUNT(lt.link_id) as link_count
+		FROM tags t
+		INNER JOIN link_tags lt ON lt.tag_id = t.id
+		WHERE t.name > ? OR (t.name = ? AND t.id > ?)
+		GROUP BY t.id
+		HAVING COUNT(lt.link_id) >= 1
+		ORDER BY t.name ASC, t.id ASC
+		LIMIT ?
+	`), cursorName, cursorName, cursorID, limit)
+	return tags, err
+}
+
 // ListAll returns all tags ordered by name.
 func (s *TagStore) ListAll(ctx context.Context) ([]*Tag, error) {
 	var tags []*Tag

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -197,6 +197,29 @@ func (s *UserStore) ListAll(ctx context.Context) ([]*User, error) {
 	return users, nil
 }
 
+// ListAllPaginated returns users ordered by (display_name, id), keyset-paginated.
+// Pass cursorName/cursorID from the last row of the previous page (empty for
+// the first page). Fetches up to limit rows.
+// Governing: SPEC-0005 REQ "Pagination", SPEC-0004 REQ "Admin Dashboard"
+func (s *UserStore) ListAllPaginated(ctx context.Context, limit int, cursorName, cursorID string) ([]*User, error) {
+	var users []*User
+	if cursorName == "" && cursorID == "" {
+		err := s.db.SelectContext(ctx, &users, s.q(`
+			SELECT * FROM users
+			ORDER BY display_name ASC, id ASC
+			LIMIT ?
+		`), limit)
+		return users, err
+	}
+	err := s.db.SelectContext(ctx, &users, s.q(`
+		SELECT * FROM users
+		WHERE display_name > ? OR (display_name = ? AND id > ?)
+		ORDER BY display_name ASC, id ASC
+		LIMIT ?
+	`), cursorName, cursorName, cursorID, limit)
+	return users, err
+}
+
 // UpdateRole sets the role for the given user and returns the updated record.
 // Governing: SPEC-0004 REQ "Admin Dashboard" — inline role toggle
 func (s *UserStore) UpdateRole(ctx context.Context, id, role string) (*User, error) {


### PR DESCRIPTION
## Summary
Closes #165 (CRITICAL — Code vs Spec drift from the 2026-06 design audit).

SPEC-0005 REQ "Pagination" requires all four list endpoints to support `?limit=` (default 50, max 200, silently capped) and an opaque `next_cursor`. Previously unimplemented — `next_cursor` was always `null` and no limit/cap was applied.

## Changes
- `internal/api/pagination.go` (new): `parseLimit` (default 50 / cap 200 / invalid→default), `parseCursor`, `encodeCursor`/`decodeCursor` (URL-safe base64 of `sortKey\x00id`).
- Paginated store methods on links, tags, users (keyset `(sortKey, id)` for deterministic ordering with tiebreaker).
- Wired `/api/v1/links` (admin vs owner/shared), `/api/v1/tags`, `/api/v1/admin/users`, `/api/v1/admin/links`. Existing response shapes preserved (`toLinkResponse` etc.).
- Regenerated Swagger (`limit`/`cursor` params) to keep the SPEC-0007 freshness check green.

## Testing
- `go build ./...` clean, `go test ./...` green.
- New `internal/api/pagination_test.go`: default limit, cap at 200, invalid-limit fallback, and cursor round-trips (no dupes, all rows collected, null cursor on last page) for all four endpoints.

Governing: SPEC-0005 REQ "Pagination", ADR-0008

🤖 Generated with [Claude Code](https://claude.com/claude-code)