### PR TITLE
Populate owners/tags/visibility on GET /tags/{slug}/links (SPEC-0005)

### DIFF
--- a/internal/api/links.go
+++ b/internal/api/links.go
@@ -665,7 +665,15 @@ func (h *linksAPIHandler) RemoveOwner(w http.ResponseWriter, r *http.Request) {
 
 // toLinkResponse converts a store.Link to an API LinkResponse, including owners and tags.
 func (h *linksAPIHandler) toLinkResponse(ctx context.Context, link *store.Link) (*LinkResponse, error) {
-	owners, err := h.ownership.ListOwnerUsers(link.ID)
+	return buildLinkResponse(ctx, h.links, h.ownership, link)
+}
+
+// buildLinkResponse converts a store.Link to an API LinkResponse, populating
+// owners, tags, and visibility. Shared by every endpoint that returns links so
+// the JSON shape stays consistent.
+// Governing: SPEC-0005 REQ "API Response Structures"
+func buildLinkResponse(ctx context.Context, links *store.LinkStore, ownership *store.OwnershipStore, link *store.Link) (*LinkResponse, error) {
+	owners, err := ownership.ListOwnerUsers(link.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -679,7 +687,7 @@ func (h *linksAPIHandler) toLinkResponse(ctx context.Context, link *store.Link) 
 		})
 	}
 
-	tags, err := h.links.ListTags(ctx, link.ID)
+	tags, err := links.ListTags(ctx, link.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -53,7 +53,7 @@ func NewAPIRouter(deps Deps) http.Handler {
 
 		// Tag routes.
 		// Governing: SPEC-0005 REQ "Tags"
-		registerTagRoutes(r, deps.TagStore, deps.LinkStore)
+		registerTagRoutes(r, deps.TagStore, deps.LinkStore, deps.OwnershipStore)
 
 		// User profile routes.
 		// Governing: SPEC-0005 REQ "User Profile"

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -13,14 +13,15 @@ import (
 // tagsAPIHandler provides REST handlers for tag endpoints.
 // Governing: SPEC-0005 REQ "Tags"
 type tagsAPIHandler struct {
-	tags  *store.TagStore
-	links *store.LinkStore
+	tags      *store.TagStore
+	links     *store.LinkStore
+	ownership *store.OwnershipStore
 }
 
 // registerTagRoutes registers tag routes on r.
 // Governing: SPEC-0005 REQ "Tags"
-func registerTagRoutes(r chi.Router, tags *store.TagStore, links *store.LinkStore) {
-	h := &tagsAPIHandler{tags: tags, links: links}
+func registerTagRoutes(r chi.Router, tags *store.TagStore, links *store.LinkStore, ownership *store.OwnershipStore) {
+	h := &tagsAPIHandler{tags: tags, links: links, ownership: ownership}
 	r.Get("/tags", h.List)
 	r.Get("/tags/{slug}/links", h.ListLinks)
 }
@@ -126,17 +127,15 @@ func (h *tagsAPIHandler) ListLinks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Governing: SPEC-0005 REQ "API Response Structures" — consistent link shape (owners, tags, visibility)
 	resp := &LinkListResponse{Links: make([]*LinkResponse, 0, len(links))}
 	for _, l := range links {
-		resp.Links = append(resp.Links, &LinkResponse{
-			ID:          l.ID,
-			Slug:        l.Slug,
-			URL:         l.URL,
-			Title:       l.Title,
-			Description: l.Description,
-			CreatedAt:   l.CreatedAt,
-			UpdatedAt:   l.UpdatedAt,
-		})
+		lr, err := buildLinkResponse(r.Context(), h.links, h.ownership, l)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal error", "internal_error")
+			return
+		}
+		resp.Links = append(resp.Links, lr)
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/api/tags_test.go
+++ b/internal/api/tags_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joestump/joe-links/internal/api"
+)
+
+// Governing: SPEC-0005 REQ "API Response Structures" — GET /tags/{slug}/links must
+// return the same link shape as other endpoints, including owners, tags, and visibility.
+func TestTags_ListLinks_FullResponseShape(t *testing.T) {
+	env := newTestEnv(t)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+	ctx := context.Background()
+
+	link, err := env.LinkStore.Create(ctx, "docs", "https://example.com", user.ID, "Docs", "team docs", "private")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+	if err := env.LinkStore.SetTags(ctx, link.ID, []string{"work"}); err != nil {
+		t.Fatalf("set tags: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/tags/work/links", nil)
+	authRequest(req, token)
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp api.LinkListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Links) != 1 {
+		t.Fatalf("len(links) = %d, want 1", len(resp.Links))
+	}
+
+	got := resp.Links[0]
+	if got.Visibility != "private" {
+		t.Errorf("visibility = %q, want %q", got.Visibility, "private")
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "work" {
+		t.Errorf("tags = %v, want [work]", got.Tags)
+	}
+	if len(got.Owners) != 1 {
+		t.Fatalf("len(owners) = %d, want 1", len(got.Owners))
+	}
+	if got.Owners[0].Email != "alice@example.com" || !got.Owners[0].IsPrimary {
+		t.Errorf("owner = %+v, want primary alice@example.com", got.Owners[0])
+	}
+}


### PR DESCRIPTION
## Summary
Closes #167 (WARNING — Code vs Spec drift, 2026-06 audit).

`GET /api/v1/tags/{slug}/links` built `LinkResponse` inline and returned empty `owners`, `tags`, and `visibility`, unlike every other link endpoint (which use `toLinkResponse`).

## Changes
- Extracted package-level `buildLinkResponse(ctx, links, ownership, link)`; `linksAPIHandler.toLinkResponse` now delegates to it (single source of truth for link JSON shape).
- `tagsAPIHandler` gains an `OwnershipStore` (threaded via `registerTagRoutes`) and `ListLinks` uses the shared builder.
- New `internal/api/tags_test.go` asserts the response includes `visibility`, `tags`, and the primary owner.

## Testing
- `go build ./...` clean, `go test ./internal/api/...` green.

Governing: SPEC-0005 REQ "API Response Structures", ADR-0008

🤖 Generated with [Claude Code](https://claude.com/claude-code)