### PR TITLE
Add created_at column to link_owners (SPEC-0002)

### DIFF
--- a/internal/db/migrations/00013_add_link_owners_created_at.go
+++ b/internal/db/migrations/00013_add_link_owners_created_at.go
@@ -1,0 +1,48 @@
+package migrations
+
+// Governing: SPEC-0002 REQ "Multi-Ownership via link_owners", ADR-0005
+// Adds the spec-mandated created_at column to link_owners.
+//
+// This is a Go migration because SQLite does not permit a non-constant default
+// (CURRENT_TIMESTAMP) on ALTER TABLE ADD COLUMN, while PostgreSQL and MySQL do.
+// On SQLite the column is added nullable and existing rows are backfilled; the
+// application always supplies created_at explicitly on insert.
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddLinkOwnersCreatedAt, downAddLinkOwnersCreatedAt)
+}
+
+func upAddLinkOwnersCreatedAt(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range linkOwnersCreatedAtUpStmts() {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downAddLinkOwnersCreatedAt(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `ALTER TABLE link_owners DROP COLUMN created_at`)
+	return err
+}
+
+func linkOwnersCreatedAtUpStmts() []string {
+	switch dialect {
+	case "postgres", "mysql":
+		return []string{
+			`ALTER TABLE link_owners ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP`,
+		}
+	default: // sqlite3 — constant default only on ADD COLUMN, so add nullable then backfill
+		return []string{
+			`ALTER TABLE link_owners ADD COLUMN created_at TIMESTAMP`,
+			`UPDATE link_owners SET created_at = CURRENT_TIMESTAMP WHERE created_at IS NULL`,
+		}
+	}
+}

--- a/internal/store/link_store.go
+++ b/internal/store/link_store.go
@@ -97,8 +97,8 @@ func (s *LinkStore) Create(ctx context.Context, slug, url, ownerID, title, descr
 	}
 
 	_, err = tx.ExecContext(ctx, tx.Rebind(`
-		INSERT INTO link_owners (link_id, user_id, is_primary) VALUES (?, ?, 1)
-	`), id, ownerID)
+		INSERT INTO link_owners (link_id, user_id, is_primary, created_at) VALUES (?, ?, 1, ?)
+	`), id, ownerID, now)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/links_test.go
+++ b/internal/store/links_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -250,5 +251,35 @@ func TestLinkStore_ListByTag(t *testing.T) {
 	}
 	if links[0].Slug != "tag-filter" {
 		t.Errorf("slug = %q, want %q", links[0].Slug, "tag-filter")
+	}
+}
+
+// Governing: SPEC-0002 REQ "Multi-Ownership via link_owners" — created_at column populated on insert.
+func TestLinkStore_Create_OwnerCreatedAt(t *testing.T) {
+	db := testutil.NewTestDB(t)
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	ctx := context.Background()
+
+	u, err := us.Upsert(ctx, "test", "sub1", "owner@example.com", "Owner", "")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	link, err := ls.Create(ctx, "ts-link", "https://example.com", u.ID, "", "", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var createdAt sql.NullTime
+	if err := db.QueryRowx(
+		db.Rebind(`SELECT created_at FROM link_owners WHERE link_id = ? AND user_id = ?`),
+		link.ID, u.ID,
+	).Scan(&createdAt); err != nil {
+		t.Fatalf("query created_at: %v", err)
+	}
+	if !createdAt.Valid || createdAt.Time.IsZero() {
+		t.Errorf("link_owners.created_at = %v, want a non-zero timestamp", createdAt)
 	}
 }

--- a/internal/store/ownership.go
+++ b/internal/store/ownership.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -32,8 +33,8 @@ func (s *OwnershipStore) q(query string) string { return s.db.Rebind(query) }
 // Returns ErrAlreadyOwner if already present.
 func (s *OwnershipStore) AddOwner(linkID, userID string) error {
 	_, err := s.db.Exec(
-		s.q(`INSERT INTO link_owners (link_id, user_id, is_primary) VALUES (?, ?, 0)`),
-		linkID, userID,
+		s.q(`INSERT INTO link_owners (link_id, user_id, is_primary, created_at) VALUES (?, ?, 0, ?)`),
+		linkID, userID, time.Now().UTC(),
 	)
 	if err != nil {
 		if isUniqueConstraintError(err) {
@@ -47,8 +48,8 @@ func (s *OwnershipStore) AddOwner(linkID, userID string) error {
 // AddPrimaryOwner adds userID as the primary owner during link creation.
 func (s *OwnershipStore) AddPrimaryOwner(linkID, userID string) error {
 	_, err := s.db.Exec(
-		s.q(`INSERT INTO link_owners (link_id, user_id, is_primary) VALUES (?, ?, 1)`),
-		linkID, userID,
+		s.q(`INSERT INTO link_owners (link_id, user_id, is_primary, created_at) VALUES (?, ?, 1, ?)`),
+		linkID, userID, time.Now().UTC(),
 	)
 	return err
 }


### PR DESCRIPTION
## Summary
Closes #168 (WARNING — Code vs ADR drift, 2026-06 audit).

`link_owners` omitted the `created_at` column required by SPEC-0002 REQ "Multi-Ownership via link_owners" / ADR-0005.

## Changes
- `internal/db/migrations/00013_add_link_owners_created_at.go` (Go migration, dialect-aware like `00011`): SQLite can't take a `CURRENT_TIMESTAMP` default on `ALTER ADD COLUMN`, so it adds the column nullable then backfills; postgres/mysql use `NOT NULL DEFAULT CURRENT_TIMESTAMP`.
- All three `link_owners` insert sites (`LinkStore.Create`, `OwnershipStore.AddOwner`, `AddPrimaryOwner`) now populate `created_at` explicitly with `time.Now().UTC()`.
- Test asserts the primary owner row has a non-zero `created_at`.

## Testing
- `go build ./...` clean, `go test ./...` green (migration runs on SQLite in tests).

Governing: SPEC-0002 REQ "Multi-Ownership via link_owners", ADR-0005

🤖 Generated with [Claude Code](https://claude.com/claude-code)