### PR TITLE
LLM suggestion hardening (SPEC-0017)

### DIFF
--- a/internal/api/suggest.go
+++ b/internal/api/suggest.go
@@ -3,12 +3,19 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 
 	"github.com/joestump/joe-links/internal/auth"
 	"github.com/joestump/joe-links/internal/llm"
+	"github.com/joestump/joe-links/internal/store"
 )
+
+// maxRawLogBytes bounds how much of a malformed LLM response we log, to avoid
+// flooding the logs with a pathologically large model response.
+// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON"
+const maxRawLogBytes = 2048
 
 // SuggestRequest is the body for POST /api/v1/links/suggest.
 // Governing: SPEC-0017 REQ "Suggest API Endpoint"
@@ -78,15 +85,51 @@ func (h *suggestAPIHandler) Suggest(w http.ResponseWriter, r *http.Request) {
 		Description: req.Description,
 	})
 	if err != nil {
-		log.Printf("api: LLM suggest error: %v", err)
+		// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON"
+		// On a JSON parse failure the server MUST log the RAW LLM response text.
+		var malformed *llm.MalformedResponseError
+		if errors.As(err, &malformed) {
+			raw := malformed.Raw
+			if len(raw) > maxRawLogBytes {
+				raw = raw[:maxRawLogBytes] + "...(truncated)"
+			}
+			log.Printf("api: LLM suggest malformed response: %v; raw=%q", malformed.Err, raw)
+		} else {
+			log.Printf("api: LLM suggest error: %v", err)
+		}
 		writeError(w, http.StatusBadGateway, "LLM provider error", "LLM_ERROR")
 		return
 	}
 
+	// Governing: SPEC-0017 REQ "Default Prompt Template"
+	// Suggested slugs MUST follow the same validation rules as user-supplied slugs.
+	// Degrade gracefully: if the model returns an invalid slug, blank it out rather
+	// than failing the whole request — the other suggested fields are still useful.
+	slug := resp.Slug
+	if slug != "" {
+		if err := store.ValidateSlugFormat(slug); err != nil {
+			log.Printf("api: LLM suggested invalid slug %q, omitting: %v", slug, err)
+			slug = ""
+		}
+	}
+
+	// Likewise drop title/description that violate length limits rather than
+	// rejecting the whole suggestion. Validate each field independently so an
+	// over-long title doesn't mask an over-long description (and vice versa).
+	title, description := resp.Title, resp.Description
+	if err := store.ValidateLinkText(title, ""); err != nil {
+		log.Printf("api: LLM suggested title failed validation, omitting: %v", err)
+		title = ""
+	}
+	if err := store.ValidateLinkText("", description); err != nil {
+		log.Printf("api: LLM suggested description failed validation, omitting: %v", err)
+		description = ""
+	}
+
 	writeJSON(w, http.StatusOK, SuggestResponseBody{
-		Slug:        resp.Slug,
-		Title:       resp.Title,
-		Description: resp.Description,
+		Slug:        slug,
+		Title:       title,
+		Description: description,
 		Tags:        resp.Tags,
 	})
 }

--- a/internal/api/suggest_test.go
+++ b/internal/api/suggest_test.go
@@ -79,7 +79,7 @@ func TestSuggest_Unauthenticated_401(t *testing.T) {
 	called := false
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
+		_, _ = w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
 	})
 	env := newTestEnvWithSuggester(t, sg)
 
@@ -97,7 +97,7 @@ func TestSuggest_MissingURL_400(t *testing.T) {
 	called := false
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
+		_, _ = w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
 	})
 	env := newTestEnvWithSuggester(t, sg)
 	user := seedUser(t, env, "alice@example.com", "user")
@@ -116,7 +116,7 @@ func TestSuggest_MissingURL_400(t *testing.T) {
 func TestSuggest_ProviderError_502(t *testing.T) {
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error":"boom"}`))
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
 	})
 	env := newTestEnvWithSuggester(t, sg)
 	user := seedUser(t, env, "alice@example.com", "user")
@@ -132,7 +132,7 @@ func TestSuggest_ProviderError_502(t *testing.T) {
 func TestSuggest_MalformedJSON_502(t *testing.T) {
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
 		// Valid OpenAI envelope, but the model's content is not the expected JSON.
-		w.Write([]byte(openaiContentResponse("this is not json at all")))
+		_, _ = w.Write([]byte(openaiContentResponse("this is not json at all")))
 	})
 	env := newTestEnvWithSuggester(t, sg)
 	user := seedUser(t, env, "alice@example.com", "user")
@@ -147,7 +147,7 @@ func TestSuggest_MalformedJSON_502(t *testing.T) {
 // Scenario: Happy path -> 200 with fields populated.
 func TestSuggest_HappyPath_200(t *testing.T) {
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(openaiContentResponse(
+		_, _ = w.Write([]byte(openaiContentResponse(
 			`{"slug":"go-docs","title":"Go Docs","description":"The Go docs.","tags":["go","docs"]}`)))
 	})
 	env := newTestEnvWithSuggester(t, sg)
@@ -182,7 +182,7 @@ func TestSuggest_HappyPath_200(t *testing.T) {
 func TestSuggest_InvalidSlug_Omitted(t *testing.T) {
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
 		// "Go Docs!" has uppercase, spaces, and punctuation — invalid slug.
-		w.Write([]byte(openaiContentResponse(
+		_, _ = w.Write([]byte(openaiContentResponse(
 			`{"slug":"Go Docs!","title":"Go Docs","description":"The Go docs.","tags":["go"]}`)))
 	})
 	env := newTestEnvWithSuggester(t, sg)
@@ -209,7 +209,7 @@ func TestSuggest_InvalidSlug_Omitted(t *testing.T) {
 // Scenario: A reserved slug (e.g. "admin") is also treated as invalid and omitted.
 func TestSuggest_ReservedSlug_Omitted(t *testing.T) {
 	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(openaiContentResponse(
+		_, _ = w.Write([]byte(openaiContentResponse(
 			`{"slug":"admin","title":"Admin","description":"","tags":[]}`)))
 	})
 	env := newTestEnvWithSuggester(t, sg)

--- a/internal/api/suggest_test.go
+++ b/internal/api/suggest_test.go
@@ -1,0 +1,231 @@
+// Governing: SPEC-0017 REQ "Suggest API Endpoint", REQ "Default Prompt Template", REQ "LLM Provider Configuration"
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joestump/joe-links/internal/api"
+	"github.com/joestump/joe-links/internal/config"
+	"github.com/joestump/joe-links/internal/llm"
+)
+
+// newFakeLLMSuggester spins up an httptest.Server that mimics an OpenAI
+// chat-completions endpoint and returns an openai-compatible Suggester wired to
+// it. The handler receives the request and writes whatever status/body it wants,
+// letting tests drive provider behaviour deterministically. The server is
+// registered for cleanup via t.Cleanup.
+func newFakeLLMSuggester(t *testing.T, handler http.HandlerFunc) llm.Suggester {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{}
+	cfg.LLM.Provider = "openai-compatible"
+	cfg.LLM.BaseURL = srv.URL // suggester appends /v1/chat/completions
+	cfg.LLM.Model = "test-model"
+
+	sg, err := llm.New(cfg)
+	if err != nil {
+		t.Fatalf("llm.New: %v", err)
+	}
+	if sg == nil {
+		t.Fatal("llm.New returned nil suggester for openai-compatible provider")
+	}
+	return sg
+}
+
+// openaiContentResponse builds the JSON envelope an OpenAI-style API returns,
+// embedding content (the model's "text") as the assistant message.
+func openaiContentResponse(content string) string {
+	body := map[string]any{
+		"choices": []map[string]any{
+			{"message": map[string]any{"content": content}},
+		},
+	}
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+func postSuggest(t *testing.T, env *testEnv, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/links/suggest", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		authRequest(req, token)
+	}
+	rec := httptest.NewRecorder()
+	env.Router.ServeHTTP(rec, req)
+	return rec
+}
+
+// Scenario: Feature disabled (no provider configured) -> 503.
+func TestSuggest_FeatureDisabled_503(t *testing.T) {
+	env := newTestEnvWithSuggester(t, nil)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://example.com"}`)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+}
+
+// Scenario: Unauthenticated request -> 401, before any LLM call.
+func TestSuggest_Unauthenticated_401(t *testing.T) {
+	called := false
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+
+	rec := postSuggest(t, env, "", `{"url":"https://example.com"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Error("LLM backend was contacted on an unauthenticated request")
+	}
+}
+
+// Scenario: Missing url in request -> 400.
+func TestSuggest_MissingURL_400(t *testing.T) {
+	called := false
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(openaiContentResponse(`{"slug":"x"}`)))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"title":"no url here"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if called {
+		t.Error("LLM backend was contacted despite missing url")
+	}
+}
+
+// Scenario: Provider returns a non-2xx error -> 502.
+func TestSuggest_ProviderError_502(t *testing.T) {
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"boom"}`))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://example.com"}`)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+}
+
+// Scenario: Provider returns malformed JSON -> 502 (and no panic; raw text logged).
+func TestSuggest_MalformedJSON_502(t *testing.T) {
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		// Valid OpenAI envelope, but the model's content is not the expected JSON.
+		w.Write([]byte(openaiContentResponse("this is not json at all")))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://example.com"}`)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+}
+
+// Scenario: Happy path -> 200 with fields populated.
+func TestSuggest_HappyPath_200(t *testing.T) {
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(openaiContentResponse(
+			`{"slug":"go-docs","title":"Go Docs","description":"The Go docs.","tags":["go","docs"]}`)))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://go.dev","title":"Go","description":"docs"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp api.SuggestResponseBody
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Slug != "go-docs" {
+		t.Errorf("slug = %q, want %q", resp.Slug, "go-docs")
+	}
+	if resp.Title != "Go Docs" {
+		t.Errorf("title = %q, want %q", resp.Title, "Go Docs")
+	}
+	if resp.Description != "The Go docs." {
+		t.Errorf("description = %q, want %q", resp.Description, "The Go docs.")
+	}
+	if len(resp.Tags) != 2 {
+		t.Errorf("len(tags) = %d, want 2", len(resp.Tags))
+	}
+}
+
+// Scenario: Happy path, but the suggested slug is invalid -> slug is omitted
+// (blanked) while the other fields are still returned. Governing: #170.
+func TestSuggest_InvalidSlug_Omitted(t *testing.T) {
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		// "Go Docs!" has uppercase, spaces, and punctuation — invalid slug.
+		w.Write([]byte(openaiContentResponse(
+			`{"slug":"Go Docs!","title":"Go Docs","description":"The Go docs.","tags":["go"]}`)))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://go.dev"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp api.SuggestResponseBody
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Slug != "" {
+		t.Errorf("slug = %q, want empty (invalid slug must be omitted)", resp.Slug)
+	}
+	if resp.Title != "Go Docs" {
+		t.Errorf("title = %q, want %q (other fields must survive)", resp.Title, "Go Docs")
+	}
+}
+
+// Scenario: A reserved slug (e.g. "admin") is also treated as invalid and omitted.
+func TestSuggest_ReservedSlug_Omitted(t *testing.T) {
+	sg := newFakeLLMSuggester(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(openaiContentResponse(
+			`{"slug":"admin","title":"Admin","description":"","tags":[]}`)))
+	})
+	env := newTestEnvWithSuggester(t, sg)
+	user := seedUser(t, env, "alice@example.com", "user")
+	token := seedToken(t, env, user.ID)
+
+	rec := postSuggest(t, env, token, `{"url":"https://example.com/admin"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp api.SuggestResponseBody
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Slug != "" {
+		t.Errorf("slug = %q, want empty (reserved slug must be omitted)", resp.Slug)
+	}
+}

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/joestump/joe-links/internal/api"
 	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/llm"
 	"github.com/joestump/joe-links/internal/store"
 	"github.com/joestump/joe-links/internal/testutil"
 )
@@ -25,6 +26,14 @@ type testEnv struct {
 // newTestEnv creates an in-memory SQLite test database, runs migrations,
 // and wires up the full API router with real stores.
 func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	return newTestEnvWithSuggester(t, nil)
+}
+
+// newTestEnvWithSuggester is like newTestEnv but also injects an llm.Suggester
+// into the API router (nil means LLM suggestions are disabled).
+// Governing: SPEC-0017 REQ "Suggest API Endpoint"
+func newTestEnvWithSuggester(t *testing.T, suggester llm.Suggester) *testEnv {
 	t.Helper()
 	db := testutil.NewTestDB(t)
 
@@ -45,6 +54,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		TagStore:         tags,
 		UserStore:        us,
 		ClickStore:       cs,
+		Suggester:        suggester,
 	}
 
 	router := api.NewAPIRouter(deps)

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	anthropicAPIURL     = "https://api.anthropic.com/v1/messages"
-	anthropicVersion    = "2023-06-01"
+	anthropicAPIURL       = "https://api.anthropic.com/v1/messages"
+	anthropicVersion      = "2023-06-01"
 	defaultAnthropicModel = "claude-haiku-4-5-20251001"
 )
 
@@ -22,6 +22,7 @@ type anthropicSuggester struct {
 	apiKey       string
 	model        string
 	promptCustom string
+	apiURL       string // overridable for testing; defaults to anthropicAPIURL
 	client       *http.Client
 }
 
@@ -34,6 +35,7 @@ func newAnthropicSuggester(cfg *config.Config) *anthropicSuggester {
 		apiKey:       cfg.LLM.APIKey,
 		model:        model,
 		promptCustom: cfg.LLM.Prompt,
+		apiURL:       anthropicAPIURL,
 		client:       &http.Client{},
 	}
 }
@@ -72,7 +74,7 @@ func (a *anthropicSuggester) Suggest(ctx context.Context, req SuggestRequest) (*
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(payload))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.apiURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -105,8 +107,10 @@ func (a *anthropicSuggester) Suggest(ctx context.Context, req SuggestRequest) (*
 	}
 
 	var suggestion SuggestResponse
+	// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON"
+	// Carry the raw model output out via a typed error so the handler can log it.
 	if err := json.Unmarshal([]byte(apiResp.Content[0].Text), &suggestion); err != nil {
-		return nil, fmt.Errorf("decode suggestion JSON: %w", err)
+		return nil, &MalformedResponseError{Raw: apiResp.Content[0].Text, Err: err}
 	}
 
 	return &suggestion, nil

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -26,7 +26,7 @@ func anthropicEnvelope(text string) string {
 func TestAnthropic_MalformedContent_ReturnsRawError(t *testing.T) {
 	const raw = "<<<not json>>>"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(anthropicEnvelope(raw)))
+		_, _ = w.Write([]byte(anthropicEnvelope(raw)))
 	}))
 	t.Cleanup(srv.Close)
 

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -1,0 +1,53 @@
+// Governing: SPEC-0017 REQ "LLM Provider Abstraction", REQ "Default Prompt Template"
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joestump/joe-links/internal/config"
+)
+
+func anthropicEnvelope(text string) string {
+	b, _ := json.Marshal(map[string]any{
+		"content": []map[string]any{
+			{"type": "text", "text": text},
+		},
+	})
+	return string(b)
+}
+
+// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON" (#169)
+// The anthropic suggester must also surface raw text via *MalformedResponseError.
+func TestAnthropic_MalformedContent_ReturnsRawError(t *testing.T) {
+	const raw = "<<<not json>>>"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(anthropicEnvelope(raw)))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &config.Config{}
+	cfg.LLM.Provider = "anthropic"
+	cfg.LLM.APIKey = "sk"
+	cfg.LLM.Model = "test-model"
+	sg := newAnthropicSuggester(cfg)
+	// Point the suggester at the fake server.
+	sg.client = srv.Client()
+	sg.apiURL = srv.URL
+
+	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var mre *MalformedResponseError
+	if !errors.As(err, &mre) {
+		t.Fatalf("error type = %T, want *MalformedResponseError", err)
+	}
+	if mre.Raw != raw {
+		t.Errorf("Raw = %q, want %q", mre.Raw, raw)
+	}
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -28,6 +28,21 @@ type Suggester interface {
 	Suggest(ctx context.Context, req SuggestRequest) (*SuggestResponse, error)
 }
 
+// MalformedResponseError is returned when the model's content cannot be parsed
+// as the expected suggestion JSON structure. It carries the raw model output so
+// callers can log it for debugging.
+// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON"
+type MalformedResponseError struct {
+	Raw string // raw text content returned by the model
+	Err error  // underlying json.Unmarshal error
+}
+
+func (e *MalformedResponseError) Error() string {
+	return fmt.Sprintf("decode suggestion JSON: %v", e.Err)
+}
+
+func (e *MalformedResponseError) Unwrap() error { return e.Err }
+
 // New creates a Suggester based on the config. Returns nil when LLMProvider is
 // unset, meaning LLM suggestions are disabled.
 func New(cfg *config.Config) (Suggester, error) {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -86,7 +86,12 @@ func (o *openaiSuggester) Suggest(ctx context.Context, req SuggestRequest) (*Sug
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	// Governing: SPEC-0017 REQ "LLM Provider Configuration" scenario "Ollama / custom endpoint"
+	// Only send the Authorization header when an API key is configured; keyless
+	// providers (e.g. local Ollama) reject or are confused by an empty bearer.
+	if o.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+	}
 
 	resp, err := o.client.Do(httpReq)
 	if err != nil {
@@ -113,8 +118,10 @@ func (o *openaiSuggester) Suggest(ctx context.Context, req SuggestRequest) (*Sug
 	}
 
 	var suggestion SuggestResponse
+	// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON"
+	// Carry the raw model output out via a typed error so the handler can log it.
 	if err := json.Unmarshal([]byte(apiResp.Choices[0].Message.Content), &suggestion); err != nil {
-		return nil, fmt.Errorf("decode suggestion JSON: %w", err)
+		return nil, &MalformedResponseError{Raw: apiResp.Choices[0].Message.Content, Err: err}
 	}
 
 	return &suggestion, nil

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,92 @@
+// Governing: SPEC-0017 REQ "LLM Provider Configuration", REQ "LLM Provider Abstraction", REQ "Default Prompt Template"
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/joestump/joe-links/internal/config"
+)
+
+func openaiEnvelope(content string) string {
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{
+			{"message": map[string]any{"content": content}},
+		},
+	})
+	return string(b)
+}
+
+func newOpenAITestSuggester(t *testing.T, provider, apiKey string, handler http.HandlerFunc) *openaiSuggester {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	cfg := &config.Config{}
+	cfg.LLM.Provider = provider
+	cfg.LLM.APIKey = apiKey
+	cfg.LLM.BaseURL = srv.URL
+	cfg.LLM.Model = "test-model"
+	return newOpenAISuggester(cfg)
+}
+
+// Governing: SPEC-0017 REQ "LLM Provider Configuration" scenario "Ollama / custom endpoint" (#172)
+// When no API key is configured, the Authorization header MUST be omitted.
+func TestOpenAI_NoAPIKey_OmitsAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	var hadAuth bool
+	sg := newOpenAITestSuggester(t, "openai-compatible", "", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, hadAuth = r.Header["Authorization"]
+		w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
+	})
+
+	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if hadAuth || gotAuth != "" {
+		t.Errorf("Authorization header was sent (%q); want it omitted for keyless provider", gotAuth)
+	}
+}
+
+// When an API key IS configured, the Authorization: Bearer header MUST be present.
+func TestOpenAI_WithAPIKey_SetsAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	sg := newOpenAITestSuggester(t, "openai", "sk-test-123", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
+	})
+
+	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
+	if err != nil {
+		t.Fatalf("Suggest: %v", err)
+	}
+	if gotAuth != "Bearer sk-test-123" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer sk-test-123")
+	}
+}
+
+// Governing: SPEC-0017 REQ "Default Prompt Template" scenario "LLM returns malformed JSON" (#169)
+// A malformed model content must surface as *MalformedResponseError carrying the raw text.
+func TestOpenAI_MalformedContent_ReturnsRawError(t *testing.T) {
+	const raw = "definitely not json {oops"
+	sg := newOpenAITestSuggester(t, "openai", "sk", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(openaiEnvelope(raw)))
+	})
+
+	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var mre *MalformedResponseError
+	if !errors.As(err, &mre) {
+		t.Fatalf("error type = %T, want *MalformedResponseError", err)
+	}
+	if mre.Raw != raw {
+		t.Errorf("Raw = %q, want %q", mre.Raw, raw)
+	}
+}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -41,7 +41,7 @@ func TestOpenAI_NoAPIKey_OmitsAuthorizationHeader(t *testing.T) {
 	sg := newOpenAITestSuggester(t, "openai-compatible", "", func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
 		_, hadAuth = r.Header["Authorization"]
-		w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
+		_, _ = w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
 	})
 
 	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
@@ -58,7 +58,7 @@ func TestOpenAI_WithAPIKey_SetsAuthorizationHeader(t *testing.T) {
 	var gotAuth string
 	sg := newOpenAITestSuggester(t, "openai", "sk-test-123", func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
+		_, _ = w.Write([]byte(openaiEnvelope(`{"slug":"x","title":"","description":"","tags":[]}`)))
 	})
 
 	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})
@@ -75,7 +75,7 @@ func TestOpenAI_WithAPIKey_SetsAuthorizationHeader(t *testing.T) {
 func TestOpenAI_MalformedContent_ReturnsRawError(t *testing.T) {
 	const raw = "definitely not json {oops"
 	sg := newOpenAITestSuggester(t, "openai", "sk", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(openaiEnvelope(raw)))
+		_, _ = w.Write([]byte(openaiEnvelope(raw)))
 	})
 
 	_, err := sg.Suggest(context.Background(), SuggestRequest{URL: "https://example.com"})


### PR DESCRIPTION
## Summary
Closes #169, #170, #171, #172 — Epic B (LLM Suggestion Hardening) from the 2026-06 design audit. The LLM suggestion subsystem shipped in v0.x but had hardening gaps the audit flagged.

## Changes
- **#169 (CRITICAL)** Raw-response logging on malformed JSON: providers return a typed `*MalformedResponseError{Raw, Err}`; `suggest.go` logs the raw model text (truncated to 2KB). User-facing 502 unchanged. Top-level envelope decode failures stay generic errors (only inner content carries raw text).
- **#170** Server-side validation of suggested `slug`/`title`/`description` using the same `store.ValidateSlugFormat`/`ValidateLinkText` as user input; invalid fields are blanked so the rest of the suggestion still returns (graceful degradation).
- **#172** `openai.go` sets `Authorization` only when an API key is configured — no empty `Bearer` for Ollama/keyless endpoints.
- **#171** New tests (`internal/api/suggest_test.go`, `internal/llm/{openai,anthropic}_test.go`) drive fake LLM backends via `httptest.Server`: disabled→503, unauth→401, missing url→400, provider error→502, malformed→502, happy path→200, invalid/reserved slug omitted, auth-header presence/absence, raw-error threading.

## Testing
- `go build ./...` clean, `go test ./...` green (also verified `-race` during review).

Governing: SPEC-0017 REQ "Default Prompt Template", "LLM Provider Configuration", "Suggest API Endpoint", ADR-0017

🤖 Generated with [Claude Code](https://claude.com/claude-code)