### PR TITLE
UI link-list consistency + secure-link return_url (SPEC-0014/0012/0013/0010)

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -4,6 +4,7 @@ package auth
 import (
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/alexedwards/scs/v2"
@@ -15,6 +16,17 @@ const (
 	cookieCodeVerifier = "__auth_pkce"
 	cookieRedirect     = "__auth_redirect"
 )
+
+// safeReturnURL returns u only if it is a safe local path (begins with a single
+// "/" and is not protocol-relative), otherwise "/dashboard". This prevents an
+// open redirect via ?return_url=https://evil.com or //evil.com after login.
+// Governing: SPEC-0010 REQ "Secure Link Resolution"
+func safeReturnURL(u string) string {
+	if u == "" || u[0] != '/' || strings.HasPrefix(u, "//") || strings.HasPrefix(u, "/\\") {
+		return "/dashboard"
+	}
+	return u
+}
 
 // Handlers provides HTTP handlers for the OIDC authentication flow.
 type Handlers struct {
@@ -61,12 +73,10 @@ func (h *Handlers) Login(w http.ResponseWriter, r *http.Request) {
 	h.setPreAuthCookie(w, cookieState, state)
 	h.setPreAuthCookie(w, cookieCodeVerifier, verifier)
 
-	// Preserve the redirect URL
-	redirect := r.URL.Query().Get("redirect")
-	if redirect == "" {
-		redirect = "/dashboard"
-	}
-	h.setPreAuthCookie(w, cookieRedirect, redirect)
+	// Preserve the return URL.
+	// Governing: SPEC-0010 REQ "Secure Link Resolution" — login flow reads return_url.
+	// Sanitize to a local path to prevent an open redirect after authentication.
+	h.setPreAuthCookie(w, cookieRedirect, safeReturnURL(r.URL.Query().Get("return_url")))
 
 	http.Redirect(w, r, h.provider.AuthCodeURL(state, challenge), http.StatusFound)
 }
@@ -159,7 +169,7 @@ func (h *Handlers) Callback(w http.ResponseWriter, r *http.Request) {
 	redirectCookie, err := r.Cookie(cookieRedirect)
 	redirect := "/dashboard"
 	if err == nil && redirectCookie.Value != "" {
-		redirect = redirectCookie.Value
+		redirect = safeReturnURL(redirectCookie.Value) // defense in depth
 	}
 	clearCookie(w, cookieRedirect)
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -4,6 +4,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/joestump/joe-links/internal/store"
@@ -30,7 +31,8 @@ func (m *Middleware) RequireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userID := m.sessions.GetString(r.Context(), SessionUserIDKey)
 		if userID == "" {
-			http.Redirect(w, r, "/auth/login?redirect="+r.URL.RequestURI(), http.StatusFound)
+			// Governing: SPEC-0010 REQ "Secure Link Resolution" — login flow reads return_url
+			http.Redirect(w, r, "/auth/login?return_url="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
 			return
 		}
 

--- a/internal/auth/return_url_test.go
+++ b/internal/auth/return_url_test.go
@@ -1,0 +1,24 @@
+package auth
+
+import "testing"
+
+// Governing: SPEC-0010 REQ "Secure Link Resolution" — return_url must not enable open redirects.
+func TestSafeReturnURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"/go/secret", "/go/secret"},
+		{"/dashboard?x=1", "/dashboard?x=1"},
+		{"", "/dashboard"},
+		{"https://evil.com", "/dashboard"},
+		{"//evil.com", "/dashboard"},
+		{"/\\evil.com", "/dashboard"},
+		{"http://evil.com", "/dashboard"},
+		{"javascript:alert(1)", "/dashboard"},
+	}
+	for _, tt := range tests {
+		if got := safeReturnURL(tt.in); got != tt.want {
+			t.Errorf("safeReturnURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -58,6 +58,32 @@ type AdminLinksPage struct {
 	ShowActions    bool   // show Edit/Delete action buttons
 }
 
+// AdminLinkRowData wraps a single admin link with the display context the shared
+// link_row partial needs (keyword prefix, site URL, column flags). It mirrors the
+// dict("Link" . "Ctx" $) shape used by the link_list range so single-row HTMX
+// swaps render identically to rows in the full list.
+// Governing: SPEC-0014 REQ "Abstract Link Widget"
+type AdminLinkRowData struct {
+	Link *store.AdminLink
+	Ctx  AdminLinksPage
+}
+
+// adminLinkRowData builds the wrapper for a single admin link row swap.
+// Governing: SPEC-0014 REQ "Abstract Link Widget"
+func adminLinkRowData(r *http.Request, link *store.AdminLink) AdminLinkRowData {
+	return AdminLinkRowData{
+		Link: link,
+		Ctx: AdminLinksPage{
+			BasePage:       newBasePage(r, nil),
+			ShowTitle:      true,
+			ShowOwner:      true,
+			ShowTags:       true,
+			ShowVisibility: true,
+			ShowActions:    true,
+		},
+	}
+}
+
 // Dashboard renders the admin overview with summary stats.
 // Governing: SPEC-0004 REQ "Admin Dashboard"
 func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +175,7 @@ func (h *AdminHandler) EditLinkRow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	renderPageFragment(w, "admin/links.html", "admin_link_edit_row", link)
+	renderPageFragment(w, "admin/links.html", "admin_link_edit_row", adminLinkRowData(r, link))
 }
 
 // UpdateLink handles PUT /admin/links/{id} — updates url, title, description, visibility and returns the read-only row.
@@ -192,7 +218,8 @@ func (h *AdminHandler) UpdateLink(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "fetch failed", http.StatusInternalServerError)
 		return
 	}
-	renderPageFragment(w, "admin/links.html", "admin_link_row", link)
+	// Governing: SPEC-0014 REQ "Abstract Link Widget" — reuse shared link_row markup
+	renderFragment(w, "link_row", adminLinkRowData(r, link))
 }
 
 // DeleteLink handles DELETE /admin/links/{id} — removes the link and returns an OOB toast.
@@ -218,7 +245,8 @@ func (h *AdminHandler) LinkRow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	renderPageFragment(w, "admin/links.html", "admin_link_row", link)
+	// Governing: SPEC-0014 REQ "Abstract Link Widget" — reuse shared link_row markup
+	renderFragment(w, "link_row", adminLinkRowData(r, link))
 }
 
 // ConfirmDeleteLink renders the delete confirmation modal for a link.

--- a/internal/handler/link_row_render_test.go
+++ b/internal/handler/link_row_render_test.go
@@ -1,0 +1,137 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// Governing: SPEC-0014 REQ "Abstract Link Widget" — verify the shared link_row
+// partial and admin/profile renderers execute against their real data shapes.
+func sampleAdminLink() *store.AdminLink {
+	al := &store.AdminLink{
+		Owners:    "Alice",
+		Tags:      "go,docs",
+		OwnerSlug: "alice",
+		IsOwner:   true,
+	}
+	al.ID = "00000000-0000-0000-0000-000000000001"
+	al.Slug = "example"
+	al.URL = "https://example.com/$page"
+	al.Title = "Example"
+	al.Description = "An example link"
+	al.Visibility = "public"
+	al.CreatedAt = time.Now()
+	return al
+}
+
+func TestLinkRowRenders_AdminAndDashboard(t *testing.T) {
+	link := sampleAdminLink()
+
+	cases := []struct {
+		name      string
+		path      string
+		wantHrefs []string
+	}{
+		{"admin", "/admin/links/1/row", []string{"/admin/links/", "/admin/links/" + link.ID + "/confirm-delete"}},
+		{"dashboard", "/dashboard", []string{"/dashboard/links/" + link.ID + "/stats", "/dashboard/links/" + link.ID + "/confirm-delete"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tc.path, nil)
+			ctx := AdminLinksPage{
+				BasePage:       newBasePage(r, nil),
+				ShowTitle:      true,
+				ShowOwner:      true,
+				ShowTags:       true,
+				ShowVisibility: true,
+				ShowActions:    true,
+			}
+			rr := httptest.NewRecorder()
+			renderFragment(rr, "link_row", map[string]any{"Link": link, "Ctx": ctx})
+			body := rr.Body.String()
+			if !strings.Contains(body, `id="link-`+link.ID+`"`) {
+				t.Fatalf("missing row id; body=%s", body)
+			}
+			// shared copy button + keyword prefix present
+			if !strings.Contains(body, "Copy link") {
+				t.Errorf("missing copy button")
+			}
+			for _, h := range tc.wantHrefs {
+				if !strings.Contains(body, h) {
+					t.Errorf("expected %q in body; body=%s", h, body)
+				}
+			}
+		})
+	}
+}
+
+func TestAdminEditRowRenders(t *testing.T) {
+	link := sampleAdminLink()
+	r := httptest.NewRequest("GET", "/admin/links/1/edit", nil)
+	data := adminLinkRowData(r, link)
+	rr := httptest.NewRecorder()
+	renderPageFragment(rr, "admin/links.html", "admin_link_edit_row", data)
+	body := rr.Body.String()
+	if !strings.Contains(body, `id="link-`+link.ID+`"`) {
+		t.Fatalf("edit row id mismatch; body=%s", body)
+	}
+	if !strings.Contains(body, `hx-target="#link-`+link.ID+`"`) {
+		t.Errorf("edit row save/cancel should target #link-<id>; body=%s", body)
+	}
+}
+
+func TestProfilePageRenders(t *testing.T) {
+	link := sampleAdminLink()
+	r := httptest.NewRequest("GET", "/u/alice", nil)
+	data := ProfilePage{
+		BasePage:       newBasePage(r, nil),
+		ProfileUser:    &store.User{DisplayName: "Alice", DisplayNameSlug: "alice"},
+		Links:          []*store.AdminLink{link},
+		Page:           1,
+		TotalPages:     1,
+		TotalLinks:     1,
+		ShowOwner:      true,
+		ShowTags:       true,
+		ShowVisibility: true,
+	}
+	rr := httptest.NewRecorder()
+	render(rr, "profile.html", data)
+	body := rr.Body.String()
+	if !strings.Contains(body, "table") || !strings.Contains(body, link.Slug) {
+		t.Fatalf("profile page should render link_list table with the link; body=%s", body)
+	}
+}
+
+// Governing: SPEC-0014 — the dashboard renders link_list with []*store.Link (no
+// AdminLink owner/tag fields). Guards must keep those fields un-evaluated so the
+// dashboard never 500s on the shared partial.
+func TestDashboardLinkListRenders_StoreLink(t *testing.T) {
+	r := httptest.NewRequest("GET", "/dashboard", nil)
+	l := &store.Link{
+		ID:          "00000000-0000-0000-0000-0000000000aa",
+		Slug:        "dash-link",
+		URL:         "https://example.com",
+		Title:       "Dash",
+		Description: "d",
+		Visibility:  "public",
+		CreatedAt:   time.Now(),
+	}
+	data := DashboardPage{
+		BasePage:    newBasePage(r, nil),
+		Links:       []*store.Link{l},
+		ShowActions: true, // matches DashboardHandler.Show; all other Show* false
+	}
+	rr := httptest.NewRecorder()
+	renderFragment(rr, "link_list", data)
+	body := rr.Body.String()
+	if !strings.Contains(body, `id="link-`+l.ID+`"`) {
+		t.Fatalf("dashboard link_list missing row; body=%s", body)
+	}
+	if !strings.Contains(body, "/dashboard/links/"+l.ID+"/stats") {
+		t.Errorf("dashboard row should show stats action; body=%s", body)
+	}
+}

--- a/internal/handler/profile.go
+++ b/internal/handler/profile.go
@@ -14,15 +14,23 @@ const profilePageSize = 25
 
 // ProfilePage is the template data for the user profile page.
 // Governing: SPEC-0012 REQ "User Profile Page (GET /u/{display_name_slug})"
+// Governing: SPEC-0014 REQ "Abstract Link Widget" — renders via shared link_list partial
 type ProfilePage struct {
 	BasePage
-	ProfileUser *store.User
-	Links       []store.PublicLink
-	Page        int
-	TotalPages  int
-	TotalLinks  int
-	PrevPage    int
-	NextPage    int
+	ProfileUser    *store.User
+	Links          []*store.AdminLink
+	Query          string // unused; present for shared link_list partial compatibility
+	Tag            string // unused; present for shared link_list partial compatibility
+	Page           int
+	TotalPages     int
+	TotalLinks     int
+	PrevPage       int
+	NextPage       int
+	ShowTitle      bool
+	ShowOwner      bool
+	ShowTags       bool
+	ShowVisibility bool
+	ShowActions    bool
 }
 
 // ProfileHandler provides HTTP handlers for public user profile pages.
@@ -65,7 +73,13 @@ func (h *ProfileHandler) Show(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	links, total, err := h.links.ListPublicByOwner(r.Context(), profileUser.ID, page, profilePageSize)
+	viewer := auth.UserFromContext(r.Context())
+	currentUserID := ""
+	if viewer != nil {
+		currentUserID = viewer.ID
+	}
+
+	links, total, err := h.links.ListPublicByOwner(r.Context(), profileUser.ID, currentUserID, page, profilePageSize)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -76,16 +90,18 @@ func (h *ProfileHandler) Show(w http.ResponseWriter, r *http.Request) {
 		totalPages = 1
 	}
 
-	viewer := auth.UserFromContext(r.Context())
 	data := ProfilePage{
-		BasePage:    newBasePage(r, viewer),
-		ProfileUser: profileUser,
-		Links:       links,
-		Page:        page,
-		TotalPages:  totalPages,
-		TotalLinks:  total,
-		PrevPage:    page - 1,
-		NextPage:    page + 1,
+		BasePage:       newBasePage(r, viewer),
+		ProfileUser:    profileUser,
+		Links:          links,
+		Page:           page,
+		TotalPages:     totalPages,
+		TotalLinks:     total,
+		PrevPage:       page - 1,
+		NextPage:       page + 1,
+		ShowOwner:      true,
+		ShowTags:       true,
+		ShowVisibility: true,
 	}
 
 	if isHTMX(r) {

--- a/internal/handler/resolve.go
+++ b/internal/handler/resolve.go
@@ -27,10 +27,10 @@ var varPlaceholderRe = regexp.MustCompile(`\$[a-z][a-z0-9_]*`)
 // ResolveHandler handles short link slug resolution and redirection.
 // Governing: SPEC-0016 REQ "Click Recording", ADR-0016
 type ResolveHandler struct {
-	links      *store.LinkStore
-	keywords   *store.KeywordStore
-	ownership  *store.OwnershipStore
-	clickCh    chan<- store.ClickEvent
+	links     *store.LinkStore
+	keywords  *store.KeywordStore
+	ownership *store.OwnershipStore
+	clickCh   chan<- store.ClickEvent
 }
 
 // NewResolveHandler creates a new ResolveHandler.
@@ -178,9 +178,9 @@ func (h *ResolveHandler) checkVisibility(w http.ResponseWriter, r *http.Request,
 	case "secure":
 		user := auth.UserFromContext(r.Context())
 		if user == nil {
-			// Governing: SPEC-0010 REQ "Secure Link Resolution" — redirect to login with return URL
+			// Governing: SPEC-0010 REQ "Secure Link Resolution" — redirect to login with return_url
 			returnURL := r.URL.RequestURI()
-			http.Redirect(w, r, "/auth/login?redirect="+url.QueryEscape(returnURL), http.StatusFound)
+			http.Redirect(w, r, "/auth/login?return_url="+url.QueryEscape(returnURL), http.StatusFound)
 			return false
 		}
 		// Governing: SPEC-0010 REQ "Admin Visibility Override" — admins always authorized

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -38,7 +38,7 @@ func NewStatsHandler(ls *store.LinkStore, cs *store.ClickStore, os *store.Owners
 func (h *StatsHandler) Show(w http.ResponseWriter, r *http.Request) {
 	user := auth.UserFromContext(r.Context())
 	if user == nil {
-		http.Redirect(w, r, "/auth/login?redirect="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+		http.Redirect(w, r, "/auth/login?return_url="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
 		return
 	}
 

--- a/internal/handler/templates.go
+++ b/internal/handler/templates.go
@@ -3,6 +3,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -15,19 +16,41 @@ import (
 	"github.com/joestump/joe-links/web"
 )
 
+// templateFuncs are helper functions made available to all templates.
+// Governing: SPEC-0014 REQ "Abstract Link Widget" — dict lets the shared
+// link_row partial receive both the current link and the parent context ($).
+var templateFuncs = template.FuncMap{
+	// dict builds a map from alternating key/value pairs, e.g.
+	// {{template "link_row" (dict "Link" . "Ctx" $)}}.
+	"dict": func(values ...any) (map[string]any, error) {
+		if len(values)%2 != 0 {
+			return nil, errors.New("dict requires an even number of arguments")
+		}
+		m := make(map[string]any, len(values)/2)
+		for i := 0; i < len(values); i += 2 {
+			key, ok := values[i].(string)
+			if !ok {
+				return nil, errors.New("dict keys must be strings")
+			}
+			m[key] = values[i+1]
+		}
+		return m, nil
+	},
+}
+
 // BasePage carries layout-level data available to every template.
 // Governing: SPEC-0003 REQ "Theme Persistence via Cookie"
 // Governing: SPEC-0004 REQ "Shared Base Layout" — User enables conditional admin nav link
 // Governing: SPEC-0013 REQ "Collapsible Admin Sidebar Section" — IsAdminPage drives <details open>
 type BasePage struct {
-	Theme          string      // "joe-light", "joe-dark", or "" (let inline script decide)
-	User           *store.User // nil for unauthenticated pages
-	IsAdminPage    bool        // true when current path starts with /admin
-	SiteURL        string      // scheme://host of this server (e.g. "https://go.stump.rocks")
-	ShortKeyword   string      // first label of server hostname (e.g. "go" from "go.stump.rocks")
-	BuildVersion   string      // e.g. "v0.2.15" or "dev"
-	BuildCommit    string      // short commit SHA, e.g. "abc1234"
-	BuildBranch    string      // e.g. "main"
+	Theme        string      // "joe-light", "joe-dark", or "" (let inline script decide)
+	User         *store.User // nil for unauthenticated pages
+	IsAdminPage  bool        // true when current path starts with /admin
+	SiteURL      string      // scheme://host of this server (e.g. "https://go.stump.rocks")
+	ShortKeyword string      // first label of server hostname (e.g. "go" from "go.stump.rocks")
+	BuildVersion string      // e.g. "v0.2.15" or "dev"
+	BuildCommit  string      // short commit SHA, e.g. "abc1234"
+	BuildBranch  string      // e.g. "main"
 }
 
 // newBasePage constructs a BasePage from the current request, setting theme,
@@ -97,7 +120,7 @@ func init() {
 	}
 
 	// Standalone set for global HTMX fragment rendering (partials only).
-	fragmentTmpl = template.Must(template.New("").ParseFS(web.TemplateFS, partials...))
+	fragmentTmpl = template.Must(template.New("").Funcs(templateFuncs).ParseFS(web.TemplateFS, partials...))
 
 	// Count how many page files share each basename to detect collisions.
 	baseCount := map[string]int{}
@@ -121,7 +144,7 @@ func init() {
 		files = append(files, partials...)
 		files = append(files, p)
 
-		t, err := template.New("").ParseFS(web.TemplateFS, files...)
+		t, err := template.New("").Funcs(templateFuncs).ParseFS(web.TemplateFS, files...)
 		if err != nil {
 			return fmt.Errorf("parse %s: %w", p, err)
 		}

--- a/internal/store/link_store.go
+++ b/internal/store/link_store.go
@@ -57,15 +57,6 @@ func (s *LinkStore) aggDistinct(col string) string {
 	return "COALESCE(GROUP_CONCAT(DISTINCT " + col + "), '')"
 }
 
-// aggAll returns a dialect-appropriate string aggregation expression (no dedup).
-// PostgreSQL: STRING_AGG(col, ',') — SQLite/MySQL: GROUP_CONCAT(col)
-func (s *LinkStore) aggAll(col string) string {
-	if s.db.DriverName() == "postgres" {
-		return "COALESCE(STRING_AGG(" + col + ", ','), '')"
-	}
-	return "COALESCE(GROUP_CONCAT(" + col + "), '')"
-}
-
 // Create inserts a new link and registers ownerID as the primary owner.
 // Governing: SPEC-0010 REQ "Visibility Selector in Link Forms"
 func (s *LinkStore) Create(ctx context.Context, slug, url, ownerID, title, description, visibility string) (*Link, error) {
@@ -498,45 +489,6 @@ func (s *LinkStore) ListByTag(ctx context.Context, tagSlug string) ([]*Link, err
 	return links, nil
 }
 
-// PublicLink is a Link augmented with owner display name and tags for public views.
-// Governing: SPEC-0012 REQ "Public Link Browser (GET /links)"
-type PublicLink struct {
-	ID               string    `db:"id"`
-	Slug             string    `db:"slug"`
-	URL              string    `db:"url"`
-	Title            string    `db:"title"`
-	Description      string    `db:"description"`
-	Visibility       string    `db:"visibility"`
-	CreatedAt        time.Time `db:"created_at"`
-	OwnerDisplayName string    `db:"owner_display_name"`
-	OwnerSlug        string    `db:"owner_display_name_slug"`
-	TagList          string    `db:"tag_list"` // comma-separated
-}
-
-// Tags returns tag names as a slice for template iteration.
-func (p *PublicLink) Tags() []string {
-	if p.TagList == "" {
-		return nil
-	}
-	return strings.Split(p.TagList, ",")
-}
-
-// TruncatedDescription returns the description truncated to 150 chars with ellipsis.
-func (p *PublicLink) TruncatedDescription() string {
-	if len(p.Description) <= 150 {
-		return p.Description
-	}
-	return p.Description[:150] + "..."
-}
-
-// DisplayTitle returns the title if set, otherwise the URL.
-func (p *PublicLink) DisplayTitle() string {
-	if p.Title != "" {
-		return p.Title
-	}
-	return p.URL
-}
-
 // ListPublic returns paginated public links, optionally filtered by search query.
 // Returns the matching links and total count for pagination.
 // Governing: SPEC-0012 REQ "Public Link Browser (GET /links)", REQ "Public Link Search"
@@ -639,18 +591,14 @@ func (s *LinkStore) RemoveShare(ctx context.Context, linkID, userID string) erro
 	return err
 }
 
-// Excerpt returns the description truncated to maxLen characters.
-func (p *PublicLink) Excerpt(maxLen int) string {
-	if len(p.Description) <= maxLen {
-		return p.Description
-	}
-	return p.Description[:maxLen] + "..."
-}
-
-// ListPublicByOwner returns public links owned by userID with owner and tag info, paginated.
+// ListPublicByOwner returns public links owned by userID as AdminLink rows
+// (owner display name, owner slug, tags) so the shared link_list partial can
+// render them identically to the public link browser. Paginated.
+// currentUserID is used to set IsOwner; pass "" for unauthenticated callers.
 // Returns the links, total count, and any error.
 // Governing: SPEC-0012 REQ "User Profile Page (GET /u/{display_name_slug})"
-func (s *LinkStore) ListPublicByOwner(ctx context.Context, userID string, page, perPage int) ([]PublicLink, int, error) {
+// Governing: SPEC-0014 REQ "Abstract Link Widget" — same shape as ListPublic
+func (s *LinkStore) ListPublicByOwner(ctx context.Context, userID, currentUserID string, page, perPage int) ([]*AdminLink, int, error) {
 	// Count total matching links
 	var total int
 	err := s.db.GetContext(ctx, &total, s.q(`
@@ -663,12 +611,15 @@ func (s *LinkStore) ListPublicByOwner(ctx context.Context, userID string, page, 
 	}
 
 	offset := (page - 1) * perPage
-	var links []PublicLink
+	var links []*AdminLink
 	err = s.db.SelectContext(ctx, &links, s.q(fmt.Sprintf(`
-		SELECT l.id, l.slug, l.url, l.title, l.description, l.visibility, l.created_at,
-		       MAX(u.display_name) AS owner_display_name,
-		       MAX(u.display_name_slug) AS owner_display_name_slug,
-		       %s AS tag_list
+		SELECT l.*,
+		       COALESCE(MAX(u.display_name), '') AS owners,
+		       COALESCE(MAX(u.display_name_slug), '') AS owner_slug,
+		       %s AS tags,
+		       CASE WHEN EXISTS(
+		           SELECT 1 FROM link_owners lo2 WHERE lo2.link_id = l.id AND lo2.user_id = ?
+		       ) THEN 1 ELSE 0 END AS is_owner
 		FROM links l
 		JOIN link_owners lo ON lo.link_id = l.id AND lo.is_primary = 1
 		JOIN users u ON u.id = lo.user_id
@@ -679,7 +630,7 @@ func (s *LinkStore) ListPublicByOwner(ctx context.Context, userID string, page, 
 		GROUP BY l.id
 		ORDER BY l.created_at DESC
 		LIMIT ? OFFSET ?
-	`, s.aggAll("t.name"))), userID, perPage, offset)
+	`, s.aggDistinct("t.name"))), currentUserID, userID, perPage, offset)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -128,7 +128,7 @@
                     </span>
                     Toggle theme
                 </button>
-                <a href="/dashboard/settings/tokens" class="flex items-center gap-3 text-sm px-3 py-2 rounded-lg hover:bg-base-300">
+                <a href="/dashboard/settings/tokens" data-nav="/dashboard/settings/tokens" class="flex items-center gap-3 text-sm px-3 py-2 rounded-lg hover:bg-base-300">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
                     </svg>

--- a/web/templates/pages/404.html
+++ b/web/templates/pages/404.html
@@ -15,7 +15,7 @@
             {{if .User}}
             <a href="/dashboard/links/new?slug={{.Slug}}" class="btn btn-primary">Create this link</a>
             {{else}}
-            <a href="/auth/login?redirect=/dashboard/links/new%3Fslug%3D{{.Slug}}" class="btn btn-primary">Sign in to create this link</a>
+            <a href="/auth/login?return_url=/dashboard/links/new%3Fslug%3D{{.Slug}}" class="btn btn-primary">Sign in to create this link</a>
             {{end}}
         </div>
     </div>

--- a/web/templates/pages/admin/links.html
+++ b/web/templates/pages/admin/links.html
@@ -34,79 +34,48 @@
 {{template "link_list" .}}
 {{end}}
 
-{{define "admin_link_row"}}
-<!-- Governing: SPEC-0011 REQ "Admin Links Screen" — read-only row with edit/delete actions -->
-<!-- Governing: SPEC-0010 REQ "Admin Visibility Override" — visibility badge -->
-<tr id="admin-link-{{.ID}}">
-    <td>
-        <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank">{{.Slug}}</a>
-    </td>
-    <td class="max-w-xs truncate text-sm">
-        <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
-    </td>
-    <td class="text-sm text-base-content/70">{{.Title}}</td>
-    <td class="text-sm text-base-content/70">{{.Owners}}</td>
-    <td class="text-sm">
-        {{range .TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}
-    </td>
-    <td class="text-sm">
-        <span class="badge badge-sm {{if eq .Visibility "secure"}}badge-error{{else if eq .Visibility "private"}}badge-warning{{else}}badge-ghost{{end}}">{{.Visibility}}</span>
-    </td>
-    <td class="text-xs text-base-content/50">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
-    <td class="flex gap-1 justify-end">
-        <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" -->
-        <button class="btn btn-xs btn-ghost"
-                hx-get="/admin/links/{{.ID}}/edit"
-                hx-target="#admin-link-{{.ID}}"
-                hx-swap="outerHTML">Edit</button>
-        <!-- Governing: SPEC-0011 REQ "Admin Link Deletion", SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
-        <button class="btn btn-xs btn-error btn-ghost"
-                hx-get="/admin/links/{{.ID}}/confirm-delete"
-                hx-target="#modal"
-                hx-swap="innerHTML">Delete</button>
-    </td>
-</tr>
-{{end}}
-
 {{define "admin_link_edit_row"}}
 <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — inline edit form replacing read-only row -->
 <!-- Governing: SPEC-0010 REQ "Admin Visibility Override" — visibility selector in edit form -->
-<tr id="admin-link-{{.ID}}">
-    <td>
-        <span class="font-mono font-semibold text-base-content/50">{{.Slug}}</span>
+<!-- Governing: SPEC-0014 REQ "Abstract Link Widget" — row id matches shared link_row (link-{ID}) -->
+{{- $l := .Link -}}
+{{- $ctx := .Ctx -}}
+<tr id="link-{{$l.ID}}">
+    <td class="whitespace-nowrap">
+        <span class="font-mono font-semibold"><span class="font-normal text-base-content/50">{{$ctx.ShortKeyword}}/</span>{{$l.Slug}}</span>
     </td>
     <td>
-        <input type="text" name="url" value="{{.URL}}" form="edit-link-{{.ID}}"
+        <input type="text" name="url" value="{{$l.URL}}" form="edit-link-{{$l.ID}}"
                class="input input-bordered input-xs w-full" required />
     </td>
     <td>
-        <input type="text" name="title" value="{{.Title}}" form="edit-link-{{.ID}}"
+        <input type="text" name="title" value="{{$l.Title}}" form="edit-link-{{$l.ID}}"
                class="input input-bordered input-xs w-full" />
     </td>
-    <td class="text-sm text-base-content/70">{{.Owners}}</td>
+    <td class="text-sm text-base-content/70">{{$l.Owners}}</td>
     <td>
-        <input type="text" name="description" value="{{.Description}}" form="edit-link-{{.ID}}"
+        <input type="text" name="description" value="{{$l.Description}}" form="edit-link-{{$l.ID}}"
                class="input input-bordered input-xs w-full" placeholder="Description" />
     </td>
     <td>
-        <select name="visibility" form="edit-link-{{.ID}}" class="select select-bordered select-xs w-full">
-            <option value="public" {{if eq .Visibility "public"}}selected{{end}}>public</option>
-            <option value="private" {{if eq .Visibility "private"}}selected{{end}}>private</option>
-            <option value="secure" {{if eq .Visibility "secure"}}selected{{end}}>secure</option>
+        <select name="visibility" form="edit-link-{{$l.ID}}" class="select select-bordered select-xs w-full">
+            <option value="public" {{if eq $l.Visibility "public"}}selected{{end}}>public</option>
+            <option value="private" {{if eq $l.Visibility "private"}}selected{{end}}>private</option>
+            <option value="secure" {{if eq $l.Visibility "secure"}}selected{{end}}>secure</option>
         </select>
     </td>
     <td></td>
     <td class="flex gap-1 justify-end">
-        <form id="edit-link-{{.ID}}"
-              hx-put="/admin/links/{{.ID}}"
-              hx-target="#admin-link-{{.ID}}"
+        <form id="edit-link-{{$l.ID}}"
+              hx-put="/admin/links/{{$l.ID}}"
+              hx-target="#link-{{$l.ID}}"
               hx-swap="outerHTML">
             <button type="submit" class="btn btn-xs btn-primary">Save</button>
         </form>
         <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — cancel restores original row -->
         <button class="btn btn-xs btn-ghost"
-                hx-get="/admin/links/{{.ID}}/row"
-                hx-target="#admin-link-{{.ID}}"
+                hx-get="/admin/links/{{$l.ID}}/row"
+                hx-target="#link-{{$l.ID}}"
                 hx-swap="outerHTML">Cancel</button>
     </td>
 </tr>

--- a/web/templates/pages/profile.html
+++ b/web/templates/pages/profile.html
@@ -20,33 +20,9 @@
     </div>
 
     <!-- Public links list -->
+    <!-- Governing: SPEC-0012 REQ "User Profile Page", SPEC-0014 REQ "Abstract Link Widget" — shared link_list partial -->
     {{if .Links}}
-    <div class="space-y-4">
-        {{range .Links}}
-        <div class="card bg-base-200 shadow-sm">
-            <div class="card-body p-4">
-                <div class="flex items-start justify-between gap-4">
-                    <div class="min-w-0 flex-1">
-                        <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary text-lg" target="_blank">{{.Slug}}</a>
-                        {{if .Title}}
-                        <h3 class="font-medium mt-1">{{.Title}}</h3>
-                        {{end}}
-                        {{if .Description}}
-                        <p class="text-sm text-base-content/60 mt-1">{{.Excerpt 150}}</p>
-                        {{end}}
-                        {{if .Tags}}
-                        <div class="flex flex-wrap gap-1 mt-2">
-                            {{range .Tags}}
-                            <span class="badge badge-sm badge-outline">{{.}}</span>
-                            {{end}}
-                        </div>
-                        {{end}}
-                    </div>
-                </div>
-            </div>
-        </div>
-        {{end}}
-    </div>
+    {{template "link_list" .}}
 
     <!-- Pagination -->
     {{if gt .TotalPages 1}}

--- a/web/templates/partials/link_list.html
+++ b/web/templates/partials/link_list.html
@@ -18,56 +18,7 @@
         </thead>
         <tbody id="links-table">
             {{range .Links}}
-            <tr id="link-{{.ID}}">
-                <td class="whitespace-nowrap">
-                    <div class="flex items-center gap-1">
-                            <a href="/{{.Slug}}" class="font-mono font-semibold link link-primary" target="_blank"><span class="font-normal text-base-content/50">{{$.ShortKeyword}}/</span>{{.Slug}}</a>
-                        <button class="btn btn-xs btn-ghost tooltip tooltip-right" data-tip="Copy link"
-                                onclick="(function(btn){navigator.clipboard.writeText('{{$.SiteURL}}/{{.Slug}}').then(function(){btn.setAttribute('data-tip','Copied!');setTimeout(function(){btn.setAttribute('data-tip','Copy link')},1500)})})(this)">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
-                            </svg>
-                        </button>
-                    </div>
-                </td>
-                <td class="max-w-xs truncate text-sm text-base-content/70">
-                    <a href="{{.URL}}" class="link link-hover" target="_blank">{{.URL}}</a>
-                </td>
-                {{if $.ShowTitle}}<td class="text-sm text-base-content/70">{{.Title}}</td>{{end}}
-                {{if $.ShowOwner}}<td class="text-sm text-base-content/70">
-                    {{if .OwnerSlug}}<a href="/u/{{.OwnerSlug}}" class="link link-hover">{{.Owners}}</a>{{else}}{{.Owners}}{{end}}
-                    {{if .IsOwner}}<span class="badge badge-xs badge-success ml-1">you</span>{{end}}
-                </td>{{end}}
-                {{if $.ShowTags}}<td class="text-sm">{{range .TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}</td>{{end}}
-                {{if $.ShowVisibility}}<td class="text-sm">
-                    <span class="badge badge-sm {{if eq .Visibility "secure"}}badge-error{{else if eq .Visibility "private"}}badge-warning{{else}}badge-ghost{{end}}">{{.Visibility}}</span>
-                </td>{{end}}
-                <td class="text-sm text-base-content/60">{{.Description}}</td>
-                <td class="text-sm text-base-content/60">{{.CreatedAt.Format "Jan 2, 2006"}}</td>
-                <!-- Governing: SPEC-0014 REQ "Abstract Link Widget", SPEC-0016 REQ "Link Stats Dashboard Page" -->
-                {{if $.ShowActions}}<td class="flex gap-1 justify-end">
-                    <a class="btn btn-xs btn-ghost tooltip tooltip-left" data-tip="Stats"
-                            href="/dashboard/links/{{.ID}}/stats">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                        </svg>
-                    </a>
-                    <a class="btn btn-xs btn-ghost tooltip tooltip-left" data-tip="Edit"
-                            href="/dashboard/links/{{.ID}}/edit">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-1.414a2 2 0 00-.586-1.414L11.828 15H9v-2.828l8.586-8.586z" />
-                        </svg>
-                    </a>
-                    <button class="btn btn-xs btn-ghost text-error tooltip tooltip-left" data-tip="Delete"
-                            hx-get="/dashboard/links/{{.ID}}/confirm-delete"
-                            hx-target="#modal"
-                            hx-swap="innerHTML">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                        </svg>
-                    </button>
-                </td>{{end}}
-            </tr>
+            {{template "link_row" (dict "Link" . "Ctx" $)}}
             {{end}}
         </tbody>
     </table>
@@ -98,4 +49,81 @@
 </div>
 {{end}}
 {{end}}
+{{end}}
+
+{{define "link_row"}}
+<!-- Governing: SPEC-0014 REQ "Abstract Link Widget" — single shared row used by full list and single-row swaps -->
+{{- $l := .Link -}}
+{{- $ctx := .Ctx -}}
+<tr id="link-{{$l.ID}}">
+    <td class="whitespace-nowrap">
+        <div class="flex items-center gap-1">
+                <a href="/{{$l.Slug}}" class="font-mono font-semibold link link-primary" target="_blank"><span class="font-normal text-base-content/50">{{$ctx.ShortKeyword}}/</span>{{$l.Slug}}</a>
+            <button class="btn btn-xs btn-ghost tooltip tooltip-right" data-tip="Copy link"
+                    onclick="(function(btn){navigator.clipboard.writeText('{{$ctx.SiteURL}}/{{$l.Slug}}').then(function(){btn.setAttribute('data-tip','Copied!');setTimeout(function(){btn.setAttribute('data-tip','Copy link')},1500)})})(this)">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                </svg>
+            </button>
+        </div>
+    </td>
+    <td class="max-w-xs truncate text-sm text-base-content/70">
+        <a href="{{$l.URL}}" class="link link-hover" target="_blank">{{$l.URL}}</a>
+    </td>
+    {{if $ctx.ShowTitle}}<td class="text-sm text-base-content/70">{{$l.Title}}</td>{{end}}
+    {{if $ctx.ShowOwner}}<td class="text-sm text-base-content/70">
+        {{if $l.OwnerSlug}}<a href="/u/{{$l.OwnerSlug}}" class="link link-hover">{{$l.Owners}}</a>{{else}}{{$l.Owners}}{{end}}
+        {{if $l.IsOwner}}<span class="badge badge-xs badge-success ml-1">you</span>{{end}}
+    </td>{{end}}
+    {{if $ctx.ShowTags}}<td class="text-sm">{{range $l.TagList}}<span class="badge badge-sm badge-outline mr-1">{{.}}</span>{{end}}</td>{{end}}
+    {{if $ctx.ShowVisibility}}<td class="text-sm">
+        <span class="badge badge-sm {{if eq $l.Visibility "secure"}}badge-error{{else if eq $l.Visibility "private"}}badge-warning{{else}}badge-ghost{{end}}">{{$l.Visibility}}</span>
+    </td>{{end}}
+    <td class="text-sm text-base-content/60">{{$l.Description}}</td>
+    <td class="text-sm text-base-content/60">{{$l.CreatedAt.Format "Jan 2, 2006"}}</td>
+    <!-- Governing: SPEC-0014 REQ "Abstract Link Widget", SPEC-0016 REQ "Link Stats Dashboard Page" -->
+    {{if $ctx.ShowActions}}<td class="flex gap-1 justify-end">
+        {{if $ctx.IsAdminPage}}
+        <!-- Governing: SPEC-0011 REQ "Admin Inline Link Editing" — admin edits in place -->
+        <button class="btn btn-xs btn-ghost tooltip tooltip-left" data-tip="Edit"
+                hx-get="/admin/links/{{$l.ID}}/edit"
+                hx-target="#link-{{$l.ID}}"
+                hx-swap="outerHTML">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-1.414a2 2 0 00-.586-1.414L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+        </button>
+        <!-- Governing: SPEC-0011 REQ "Admin Link Deletion", SPEC-0013 REQ "DaisyUI Delete Confirmation Modal" -->
+        <button class="btn btn-xs btn-ghost text-error tooltip tooltip-left" data-tip="Delete"
+                hx-get="/admin/links/{{$l.ID}}/confirm-delete"
+                hx-target="#modal"
+                hx-swap="innerHTML">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+        </button>
+        {{else}}
+        <a class="btn btn-xs btn-ghost tooltip tooltip-left" data-tip="Stats"
+                href="/dashboard/links/{{$l.ID}}/stats">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+        </a>
+        <a class="btn btn-xs btn-ghost tooltip tooltip-left" data-tip="Edit"
+                href="/dashboard/links/{{$l.ID}}/edit">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-1.414a2 2 0 00-.586-1.414L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+        </a>
+        <button class="btn btn-xs btn-ghost text-error tooltip tooltip-left" data-tip="Delete"
+                hx-get="/dashboard/links/{{$l.ID}}/confirm-delete"
+                hx-target="#modal"
+                hx-swap="innerHTML">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+        </button>
+        {{end}}
+    </td>{{end}}
+</tr>
 {{end}}


### PR DESCRIPTION
## Summary
Closes #173, #174, #175, #176 — Epic C (UI List Consistency) from the 2026-06 design audit.

## Changes
- **#173 (SPEC-0014)** Extracted a shared `link_row` partial in `link_list.html`; admin single-row swap endpoints (`UpdateLink`/`LinkRow`/`EditLinkRow`) now render it via an `AdminLinkRowData` wrapper, so an edited/cancelled admin row matches its neighbours (keyword prefix, inline copy, trash-icon delete) instead of divergent hard-coded markup.
- **#174 (SPEC-0012)** Profile page renders the shared `link_list` partial like the public browser; `store.ListPublicByOwner` now returns `[]*store.AdminLink` (same shape), and the dead `PublicLink`/`aggAll` were removed.
- **#175 (SPEC-0013)** Added `data-nav="/dashboard/settings/tokens"` to the API Tokens sidebar link for active highlighting.
- **#176 (SPEC-0010)** Renamed the secure-link login redirect param `redirect` → `return_url` end-to-end (setters: `resolve.go`, `stats.go`, auth middleware, `404.html`; reader: auth `Login`).
- **Security (bonus):** the `return_url` value was used as a redirect target without validation — a pre-existing **open redirect** (`?return_url=https://evil.com`). Added `safeReturnURL` (must be a local, non-protocol-relative path), applied at the cookie write and again in `Callback` (defense in depth), plus `url.QueryEscape` in the middleware.

## Testing
- New render smoke tests cover the shared partial for dashboard (real `[]*store.Link`), admin row + edit-row, and profile; `safeReturnURL` unit tests cover the open-redirect vectors.
- `go build ./...` clean, `go test ./...` green.

Governing: SPEC-0014 "Unified Link List Partial", SPEC-0012 "User Profile Page", SPEC-0013 "API Tokens Link Active State", SPEC-0010 "Secure Link Resolution"

🤖 Generated with [Claude Code](https://claude.com/claude-code)