### PR TITLE
Extension drift: refresh interval + Firefox version (SPEC-0008)

### DIFF
--- a/integrations/extension/README.md
+++ b/integrations/extension/README.md
@@ -24,7 +24,7 @@ The extension uses Manifest V3 and works across modern Chromium and Gecko browse
 
 Firefox requires a stable `browser_specific_settings.gecko.id` in `manifest.json`, which is already included. Note that temporary add-ons are removed when Firefox restarts; for persistent installation, package the extension as an `.xpi` and install via `about:addons`.
 
-Firefox 109+ is required (first stable release with MV3 support).
+Firefox 113+ is required — this is the `strict_min_version` enforced by `manifest.json`. (MV3 first shipped in Firefox 109, but this extension targets 113 as its minimum.)
 
 ### Safari
 
@@ -35,4 +35,4 @@ Safari requires converting the extension using Xcode's tooling:
 3. Build and run the generated Xcode project
 4. Enable the extension in Safari > Settings > Extensions
 
-See SPEC-0008 REQ "Firefox Compatibility" and ADR-0012 for architectural context.
+See SPEC-0008 REQ "Cross-Browser Packaging" and ADR-0012 for architectural context.

--- a/integrations/extension/background.js
+++ b/integrations/extension/background.js
@@ -175,7 +175,8 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   await refreshKeywords();
   await updateRedirectRules();
   await setActionIcon();
-  chrome.alarms.create('keyword-refresh', { periodInMinutes: 5 });
+  // Governing: SPEC-0008 REQ "Keyword Host Discovery" — default refresh interval is 60 minutes.
+  chrome.alarms.create('keyword-refresh', { periodInMinutes: 60 });
 });
 
 chrome.runtime.onStartup.addListener(async () => {

--- a/integrations/extension/manifest.json
+++ b/integrations/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "joe-links",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Navigate to go/slug links without typing http://",
   "background": {
     "service_worker": "background.js",


### PR DESCRIPTION
## Summary
Closes #179, #180 — Epic E (Browser Extension Drift) from the 2026-06 design audit. Extension-only changes (no server code).

## Changes
- **#179** Keyword refresh alarm interval `5` → `60` minutes to match SPEC-0008 REQ "Keyword Host Discovery" (default 60 min).
- **#180** Reconciled the Firefox minimum version: README said "109+" while `manifest.json` enforces `strict_min_version: 113.0`. README now states **113+** (with MV3-since-109 context). Also fixed the README footer under the Safari section to cite REQ "Cross-Browser Packaging" instead of the mislabeled "Firefox Compatibility".
- Bumped extension to **1.2.10**.

## Testing
- `manifest.json` parses; `node --check background.js` passes; CI AMO `addons-linter` validates the package.

Governing: SPEC-0008 REQ "Keyword Host Discovery", "Firefox Compatibility", "Cross-Browser Packaging", ADR-0012

🤖 Generated with [Claude Code](https://claude.com/claude-code)