### PR TITLE
Reconcile design artifacts with implementation (audit Epic F)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Go + HTMX + DaisyUI/Tailwind. Single binary.
 | `JOE_OIDC_GROUPS_CLAIM` | `groups` | OIDC claim name containing the user's groups |
 | `JOE_SHORT_KEYWORD` | *(hostname first label)* | Override the short-link prefix shown in the UI (e.g. `go`); defaults to the first DNS label of the server hostname |
 | `JOE_SESSION_LIFETIME` | `720h` | Session absolute expiry (30 days) |
+| `JOE_INSECURE_COOKIES` | `false` | When `true`, disables the `Secure` flag on session/auth cookies so login works over plain HTTP (local development only — never enable in production) |
 
 ## Key Conventions
 

--- a/docs/adrs/ADR-0015-safari-extension-testflight-distribution.md
+++ b/docs/adrs/ADR-0015-safari-extension-testflight-distribution.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-02-24
 decision-makers: joestump
 ---
@@ -41,6 +41,11 @@ Chosen option: **Option A — Apple Developer Program + TestFlight**, because it
 7-day re-signing loop, works on both iOS and macOS with a single Xcode project, integrates
 naturally into the existing GitHub Actions release pipeline, and keeps distribution intentionally
 private (no public App Store listing required).
+
+This decision is accepted, but the CI/TestFlight pipeline implementation is still
+outstanding. The automated `xcodebuild archive` → App Store Connect upload flow is
+tracked in GitHub issue #132 (with stories #133, #134, and #135); until those land,
+TestFlight builds are produced manually from the committed Xcode project.
 
 ### Consequences
 

--- a/docs/adrs/ADR-0016-link-analytics-and-prometheus-metrics.md
+++ b/docs/adrs/ADR-0016-link-analytics-and-prometheus-metrics.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-02-27
 decision-makers: joestump
 ---

--- a/docs/adrs/ADR-0017-llm-metadata-suggestions.md
+++ b/docs/adrs/ADR-0017-llm-metadata-suggestions.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-02-28
 decision-makers: joestump
 ---
@@ -44,7 +44,7 @@ The extension extracts the tab's title and a short content snippet (via `chrome.
 
 ### Confirmation
 
-* `GET /api/v1/links/suggest` endpoint present and documented in Swagger
+* `POST /api/v1/links/suggest` endpoint present and documented in Swagger
 * `JOE_LLM_PROVIDER`, `JOE_LLM_API_KEY`, `JOE_LLM_MODEL`, `JOE_LLM_BASE_URL` wired into `internal/config/config.go`
 * Extension popup shows a "Suggested" section when suggestions are returned, with one-click fill buttons for each field
 * `JOE_LLM_PROVIDER` unset → endpoint returns 503 → popup hides suggestion UI entirely

--- a/docs/openspec/specs/browser-extension/spec.md
+++ b/docs/openspec/specs/browser-extension/spec.md
@@ -100,7 +100,7 @@ project without requiring manual code changes.
 
 #### Scenario: Safari conversion
 
-- **WHEN** a developer runs `xcrun safari-web-extension-converter extension/` on the extension
+- **WHEN** a developer runs `xcrun safari-web-extension-converter integrations/extension/` on the extension
   source directory
 - **THEN** an Xcode project is produced that builds and installs on macOS without requiring
   source modifications beyond standard Xcode project configuration

--- a/docs/openspec/specs/link-analytics/spec.md
+++ b/docs/openspec/specs/link-analytics/spec.md
@@ -105,7 +105,7 @@ registered and updated:
 
 The `joelinks_links_total` and `joelinks_users_total` gauges SHOULD be updated
 on a background interval (e.g., every 60 seconds) rather than on every request.
-No `slug` label MUST be added to any counter or histogram (cardinality concern).
+A `slug` label MUST NOT be added to any counter or histogram (cardinality concern).
 
 #### Scenario: Prometheus scrape
 

--- a/docs/openspec/specs/llm-metadata-suggestions/spec.md
+++ b/docs/openspec/specs/llm-metadata-suggestions/spec.md
@@ -8,7 +8,7 @@ When creating a go-link, users must manually supply a slug, title, description, 
 
 ### Requirement: LLM Provider Configuration
 
-The server MUST support configuration of an LLM provider via environment variables. When `JOE_LLM_PROVIDER` is unset, the LLM feature MUST be completely disabled and the server MUST behave identically to a deployment with no LLM config. No code paths that contact an external LLM MUST execute when the feature is disabled.
+The server MUST support configuration of an LLM provider via environment variables. When `JOE_LLM_PROVIDER` is unset, the LLM feature MUST be completely disabled and the server MUST behave identically to a deployment with no LLM config. Code paths that contact an external LLM MUST NOT execute when the feature is disabled.
 
 The following environment variables MUST be supported:
 
@@ -54,7 +54,7 @@ The server MUST expose `POST /api/v1/links/suggest` following the REST conventio
 #### Scenario: LLM call fails
 
 - **WHEN** the configured LLM provider returns an error or times out
-- **THEN** the server returns HTTP 502 Bad Gateway with a JSON error body; the caller SHOULD surface no error to the end-user
+- **THEN** the server returns HTTP 502 Bad Gateway with a JSON error body
 
 #### Scenario: Missing required fields
 


### PR DESCRIPTION
## Summary
Closes #164 — Epic F (Design Artifact Reconciliation) from the 2026-06 design audit. Docs/artifacts only; no code changes.

## Changes
- **ADR statuses:** ADR-0016 and ADR-0017 `proposed` → `accepted` (both fully implemented). ADR-0015 `proposed` → `accepted` with a note that the CI/TestFlight pipeline is still outstanding (tracked in #132/#133/#134/#135).
- **ADR-0017** Confirmation section: fixed `GET` → `POST /api/v1/links/suggest` mislabel.
- **SPEC-0008** Cross-Browser Packaging: stale `extension/` converter path → `integrations/extension/`.
- **SPEC-0016** RFC 2119: "No `slug` label MUST be added" → "A `slug` label MUST NOT be added".
- **SPEC-0017** RFC 2119: "MUST execute when disabled" → "MUST NOT execute"; removed the misplaced client-behavior SHOULD from the server endpoint requirement (it's already a MUST under "Extension Suggestion Strip").
- **Docs:** documented `JOE_INSECURE_COOKIES` (default `false`; disables the `Secure` cookie flag for local HTTP dev) in the CLAUDE.md env-var table.
- **Housekeeping:** removed the stray empty `web/templates/pages/{links}` directory.

## Testing
- `go build ./...` clean (docs don't affect the build; the env-var doc was verified against `internal/config/config.go` + `cmd/joe-links/serve.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)