### PR TITLE
docs: document the AI metadata-suggestions feature

### DIFF
--- a/docs-site/docs-static/guides/api-guide.md
+++ b/docs-site/docs-static/guides/api-guide.md
@@ -158,6 +158,43 @@ DELETE /api/v1/links/{id}
 
 Returns `204 No Content` on success. Only owners and admins may delete.
 
+#### Suggest Link Metadata
+
+```
+POST /api/v1/links/suggest
+```
+
+```json
+{
+  "url": "https://reactjs.org/docs/hooks-intro.html",
+  "title": "Introducing Hooks",
+  "description": ""
+}
+```
+
+Uses a configured LLM to suggest a `slug`, `title`, `description`, and `tags` for a URL. `url` is required; the optional `title` and `description` are passed to the model as additional context. The browser extension calls this endpoint to pre-fill the create-link form.
+
+```json
+{
+  "slug": "react-hooks",
+  "title": "Introducing Hooks – React",
+  "description": "An overview of React Hooks and the problems they solve.",
+  "tags": ["react", "frontend", "docs"]
+}
+```
+
+Suggested values are validated server-side (the slug follows the same rules as a user-supplied slug; over-length title/description are dropped), so any field may come back empty.
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Suggestions returned |
+| `400` | `url` is missing |
+| `401` | Missing or invalid token |
+| `502` | The LLM provider returned an error or malformed response |
+| `503` | AI suggestions are not configured (`JOE_LLM_PROVIDER` unset) |
+
+This endpoint requires the server to be configured with an LLM provider — see [Configuration → AI Metadata Suggestions](./configuration.md#ai-metadata-suggestions).
+
 ### Co-Owners
 
 #### List Owners

--- a/docs-site/docs-static/guides/configuration.md
+++ b/docs-site/docs-static/guides/configuration.md
@@ -25,6 +25,28 @@ joe-links is configured via environment variables (prefixed with `JOE_`) or a `j
 | `JOE_SHORT_KEYWORD` | *(first DNS label of server hostname)* | No | Short-link prefix used in the UI and browser extension. Derived from the server hostname at request time — `go` from `go.example.com`, `links` from `links.example.com`, `localhost` from `localhost:8080`. Set explicitly if your hostname doesn't match your desired keyword |
 | `JOE_SESSION_LIFETIME` | `720h` | No | Session absolute expiry as a Go duration string |
 | `JOE_INSECURE_COOKIES` | `false` | No | Set to `true` to disable the `Secure` cookie flag (for local HTTP development) |
+| `JOE_LLM_PROVIDER` | -- | No | Enables AI metadata suggestions. One of `anthropic`, `openai`, or `openai-compatible`. Unset = feature disabled |
+| `JOE_LLM_API_KEY` | -- | No | API key for the LLM provider. Optional for keyless `openai-compatible` endpoints (e.g. Ollama) |
+| `JOE_LLM_MODEL` | *(provider default)* | No | Model name. Defaults: `claude-haiku-4-5-20251001` (anthropic), `gpt-4o-mini` (openai/compatible) |
+| `JOE_LLM_BASE_URL` | -- | No | Base URL override for `openai-compatible` providers (e.g. `http://localhost:11434/v1` for Ollama) |
+| `JOE_LLM_PROMPT` | *(built-in template)* | No | Override the built-in suggestion prompt template |
+
+## AI Metadata Suggestions
+
+Set `JOE_LLM_PROVIDER` to enable the optional AI suggestion endpoint (`POST /api/v1/links/suggest`), which the browser extension uses to pre-fill a link's slug, title, description, and tags from its URL. See the [API Guide](./api-guide.md#suggest-link-metadata) for the request and response shape. When `JOE_LLM_PROVIDER` is unset the feature is completely disabled — no LLM calls are made and the endpoint returns `503`.
+
+| Provider | `JOE_LLM_PROVIDER` | Notes |
+|----------|--------------------|-------|
+| Anthropic | `anthropic` | Requires `JOE_LLM_API_KEY`. Default model `claude-haiku-4-5-20251001` |
+| OpenAI | `openai` | Requires `JOE_LLM_API_KEY`. Default model `gpt-4o-mini` |
+| OpenAI-compatible | `openai-compatible` | Set `JOE_LLM_BASE_URL` (e.g. Ollama); `JOE_LLM_API_KEY` optional |
+
+```
+# Example: local Ollama, no API key required
+JOE_LLM_PROVIDER=openai-compatible
+JOE_LLM_BASE_URL=http://localhost:11434/v1
+JOE_LLM_MODEL=llama3.2
+```
 
 ## Admin Role Assignment
 


### PR DESCRIPTION
## Summary
Closes the documentation gap surfaced after the 2026-06 audit backlog: the LLM metadata-suggestion feature (endpoint + config) was implemented but never documented in the user-facing guides.

## Changes
- **`api-guide.md`** — new "Suggest Link Metadata" section documenting `POST /api/v1/links/suggest`: request/response JSON, the `200/400/401/502/503` status codes, the server-side validation of suggested values, and a pointer to the config requirement.
- **`configuration.md`** — added the `JOE_LLM_PROVIDER` / `JOE_LLM_API_KEY` / `JOE_LLM_MODEL` / `JOE_LLM_BASE_URL` / `JOE_LLM_PROMPT` env vars to the table, plus an "AI Metadata Suggestions" section with a provider matrix (anthropic / openai / openai-compatible) and a keyless Ollama example. Default models documented from the code (`claude-haiku-4-5-20251001`, `gpt-4o-mini`).

## Testing
- `npm run build` in `docs-site/` succeeds; the new cross-links between the two guides resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)