### PR TITLE
docs: ADR-0018 + SPEC-0018 — Agent Access via MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,22 @@ Third-party integrations live under `integrations/` to avoid polluting the repo 
 | `/sdd:check` | Quick-check code against ADRs and specs for drift |
 | `/sdd:audit` | Comprehensive design artifact alignment audit |
 | `/sdd:prime` | Load architecture context into session |
+
+### SDD Configuration
+
+- **Tracker**: GitHub
+- **Owner**: joestump
+- **Repo**: joe-links
+
+#### Branch Conventions
+- Prefix: `feature`
+- Epic Prefix: `epic`
+- Slug Max Length: 50
+
+#### PR Conventions
+- Close Keyword: `Closes`
+- Ref Keyword: `Part of`
+- Include Spec Reference: true
+
+#### Projects
+- Default Mode: per-epic

--- a/docs/adrs/ADR-0018-mcp-server-for-agent-access.md
+++ b/docs/adrs/ADR-0018-mcp-server-for-agent-access.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-07-12
 decision-makers: joestump
 extends: [ADR-0008, ADR-0009]

--- a/docs/adrs/ADR-0018-mcp-server-for-agent-access.md
+++ b/docs/adrs/ADR-0018-mcp-server-for-agent-access.md
@@ -1,0 +1,121 @@
+---
+status: proposed
+date: 2026-07-12
+decision-makers: joestump
+extends: [ADR-0008, ADR-0009]
+governs: [SPEC-0018]
+---
+
+# ADR-0018: MCP Server — In-Process Streamable HTTP Endpoint for Agent Access
+
+## Context and Problem Statement
+
+AI agents (Claude Code sessions, scheduled cloud agents, and other MCP clients) are becoming first-class users of joe-links: they want to create short links for content they produce, look links up, and share links with humans — conversationally, without screen-scraping the HTMX UI or hand-rolling REST calls. The Model Context Protocol (MCP) is the standard way agents discover and invoke tools. How should joe-links expose its link-management capabilities to MCP clients?
+
+joe-links already has a complete REST API at `/api/v1` (ADR-0008) authenticated by personal access tokens (ADR-0009), covering links, tags, shares, co-owners, stats, and LLM metadata suggestions. The MCP question is therefore purely one of *packaging*: where does the MCP server run, what transport does it speak, and how does it authenticate?
+
+## Decision Drivers
+
+* **Zero per-agent installation** — agents run on multiple machines (laptop, cloud runners, containers); requiring a local binary or npm package on each host multiplies setup and version-skew problems.
+* **Reuse existing auth** — PATs (`jl_` prefix, SHA-256 hashed, `Authorization: Bearer`) already exist with a management UI; a second credential system or an OAuth dance is unwarranted complexity for a self-hosted single-tenant service.
+* **One authorization code path** — the 2026-07 review (issues #191–#215) found several bugs caused by the UI and REST surfaces implementing authorization independently (e.g. #202, #193). A third surface must not re-implement these rules; it must call the same code.
+* **Single-binary philosophy** — the project ships one Go binary; a sidecar service or separate repo fights the deployment model (Docker image + Caddy on ie01).
+* **Client compatibility** — must work with Claude Code (`claude mcp add --transport http … --header`), Claude Desktop remote connectors, and generic MCP clients.
+* **Maintainability** — prefer an official, actively maintained SDK over hand-rolled JSON-RPC.
+
+## Considered Options
+
+* **Option 1: In-process Streamable HTTP MCP endpoint** — mount `/mcp` on the existing chi router inside the joe-links binary, implemented with the official `modelcontextprotocol/go-sdk`, authenticated by the existing PAT bearer middleware.
+* **Option 2: stdio MCP subcommand** — `joe-links mcp` in the same binary, speaking MCP over stdio and acting as a remote client of the REST API (server URL + PAT from env/flags).
+* **Option 3: External wrapper package** — a separate TypeScript/npm (or Go) MCP server that wraps the REST API, published independently.
+
+## Decision Outcome
+
+Chosen option: **Option 1 — in-process Streamable HTTP endpoint at `/mcp`**, because it is the only option with zero per-agent footprint (any MCP client anywhere reaches `https://go.stump.rocks/mcp` with a PAT header), it reuses the PAT middleware and store-layer authorization verbatim instead of adding a third divergent surface, and it keeps the single-binary deployment story intact. The official `modelcontextprotocol/go-sdk` is used (Go 1.24 already satisfies its toolchain requirement); the endpoint runs in **stateless JSON mode** (each POST self-contained, no server-held session affinity) so it stays trivially proxyable behind Caddy and safe to restart.
+
+Option 2 is explicitly kept open as a cheap future addition — the same tool definitions can be re-exported over a stdio transport for clients that cannot speak HTTP — but it is not part of this decision's scope.
+
+### Consequences
+
+* Good, because agent onboarding is one command: `claude mcp add --transport http joe-links https://go.stump.rocks/mcp --header "Authorization: Bearer jl_…"`.
+* Good, because identity, rate exposure, and revocation are exactly the PAT lifecycle that already exists (revoke the token in the UI → agent loses access).
+* Good, because MCP tool handlers share the store/service layer with `/api/v1`, so visibility and ownership rules cannot drift between surfaces (the class of bug found in #193/#202).
+* Good, because the agent-account pattern already used elsewhere in this infrastructure (a dedicated `joestump-agent` identity) maps cleanly: mint that user a PAT and agent-created links have their own owner, with sharing/co-ownership used to hand links to humans.
+* Neutral, because stateless mode forgoes MCP server-initiated features (sampling, subscriptions) — none are needed for v1 tools.
+* Bad, because stdio-only MCP clients need a bridge (e.g. `mcp-remote`) until Option 2 ships.
+* Bad, because the server binary takes on a new dependency (`modelcontextprotocol/go-sdk`) and a new public route whose protocol version tracking (MCP spec revisions) becomes a maintenance obligation.
+
+### Confirmation
+
+* `internal/mcp/` package with `// Governing: ADR-0018, SPEC-0018 REQ …` comments; tool handlers MUST call the same store methods as their REST counterparts (enforced in code review).
+* Integration test: seed a user + PAT, POST `initialize`/`tools/list`/`tools/call` to `/mcp`, assert tool inventory and that an unauthenticated request gets 401 with `WWW-Authenticate`.
+* `docs-site` gains an "Agents (MCP)" guide whose examples are exercised manually at release.
+
+## Pros and Cons of the Options
+
+### Option 1: In-process Streamable HTTP endpoint
+
+The chi router mounts the go-sdk's Streamable HTTP handler at `/mcp`, behind the existing bearer-token middleware; tools are thin adapters over the store layer.
+
+* Good, because zero installation on agent hosts; works from any machine that can reach the server.
+* Good, because auth, TLS, logging, metrics, and deployment are all inherited from the existing server.
+* Good, because one implementation of authorization rules (store layer) serves UI, REST, and MCP.
+* Good, because the official Go SDK supports Streamable HTTP + stateless mode out of the box.
+* Neutral, because MCP protocol-version churn is absorbed by SDK upgrades.
+* Bad, because clients limited to stdio need an adapter until a stdio mode exists.
+* Bad, because a malformed-request or DoS surface is added to the public server (mitigated: auth required before any tool dispatch; same exposure class as `/api/v1`).
+
+### Option 2: stdio subcommand (`joe-links mcp`)
+
+The binary runs locally per agent, speaking stdio to the client and REST to the server.
+
+* Good, because it matches the classic Claude Desktop local-server configuration with no HTTP bridge.
+* Good, because it lives in the same repo/binary — no new artifact.
+* Bad, because every agent host needs the binary installed, configured, and upgraded (version skew across Joe's machines and cloud runners).
+* Bad, because it duplicates the API surface as a *client* — request/response mapping code that can drift from the server, in exactly the way this codebase has already been bitten (#202).
+* Bad, because credentials end up in per-host MCP config files rather than one place.
+
+### Option 3: External wrapper (npm/TypeScript or separate Go repo)
+
+A standalone MCP server package wrapping the REST API.
+
+* Good, because it follows a common ecosystem pattern and could be published for other joe-links users.
+* Good, because server deploys are decoupled from MCP iteration.
+* Bad, because it introduces a second repo/toolchain (Node) to a deliberately single-binary Go project.
+* Bad, because it has all of Option 2's drift and distribution problems, plus release coordination between two artifacts.
+* Bad, because self-hosted users must now trust and run a second component.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    subgraph agents [Agent hosts — no install]
+        CC["Claude Code<br/>(--transport http)"]
+        CD["Claude Desktop<br/>(remote connector)"]
+        OTHER["Other MCP clients"]
+    end
+
+    subgraph server [joe-links binary behind Caddy]
+        MCP["/mcp<br/>Streamable HTTP (stateless)<br/>modelcontextprotocol/go-sdk"]
+        API["/api/v1<br/>REST (ADR-0008)"]
+        AUTHMW["PAT bearer middleware<br/>(ADR-0009)"]
+        STORE["store layer<br/>links · shares · owners · tags · clicks"]
+        DB[(database)]
+    end
+
+    CC -- "Bearer jl_… PAT" --> MCP
+    CD -- "Bearer jl_… PAT" --> MCP
+    OTHER -- "Bearer jl_… PAT" --> MCP
+    MCP --> AUTHMW
+    API --> AUTHMW
+    AUTHMW --> STORE
+    STORE --> DB
+```
+
+## More Information
+
+* Extends ADR-0008 (REST API layer) and ADR-0009 (PAT authentication); the MCP endpoint is a peer surface to `/api/v1`, not a replacement.
+* Related: ADR-0017 — the LLM metadata-suggestion capability is exposed as an MCP tool so agents get slug/title/tag proposals for free.
+* Requirements are formalized in SPEC-0018 (Agent Access via MCP).
+* MCP Streamable HTTP transport and authorization guidance: https://modelcontextprotocol.io/specification — the endpoint returns `401` + `WWW-Authenticate` for missing/invalid tokens per the spec's HTTP auth expectations.
+* Sharing semantics for the headline use case ("agent creates a link and shares it with me") rely on existing SPEC-0010 visibility modes: agents SHOULD create links as their own PAT identity and use share/co-owner tools to grant humans access.

--- a/docs/openspec/specs/mcp-agent-access/design.md
+++ b/docs/openspec/specs/mcp-agent-access/design.md
@@ -1,0 +1,115 @@
+# Design: Agent Access via MCP
+
+## Context
+
+AI agents are regular producers and consumers of go-links in this deployment: Claude Code sessions on multiple machines, scheduled cloud agents, and a dedicated `joestump-agent` identity that already exists across the rest of the infrastructure. Today an agent that wants to mint `go/retro-notes` must hand-roll REST calls; MCP is the protocol those agents natively speak for tool use.
+
+ADR-0018 decided the packaging: an in-process Streamable HTTP endpoint at `/mcp` inside the single joe-links binary, authenticated by existing PATs (ADR-0009 / SPEC-0006), built on the official `modelcontextprotocol/go-sdk` (Go 1.24 toolchain already satisfies it). This document covers the architecture and rationale for SPEC-0018's requirements.
+
+A hard constraint from the 2026-07 review (issues #191–#215): joe-links has been bitten repeatedly by parallel surfaces implementing authorization independently (tag pages leaking secure links #193, UI/API share-authorization divergence #202). The MCP layer is deliberately specified as a *thin adapter* over the shared store layer — it must never become a third implementation of visibility rules.
+
+## Goals / Non-Goals
+
+### Goals
+- One-command agent onboarding: `claude mcp add --transport http joe-links https://go.stump.rocks/mcp --header "Authorization: Bearer jl_…"`
+- Full create → share → hand-off loop in a single tool call (`create_link` with `share_with`)
+- Authorization identical to the REST API by construction (shared code paths)
+- Agent-safe defaults: nothing an agent creates is publicly browsable unless asked
+- Observable via the existing Prometheus registry
+
+### Non-Goals
+- Admin operations over MCP (user management, keyword CRUD, admin listings) — humans have the UI; agents don't need them
+- OAuth 2.0 authorization-server integration per the MCP auth spec — PATs are sufficient for a self-hosted, single-tenant deployment
+- stdio transport (`joe-links mcp` subcommand) — kept open by ADR-0018, not in v1
+- MCP resources/prompts (e.g. a `golink://` resource scheme) — tools cover the workflows; revisit with real demand
+- Slug auto-generation — agents supply slugs (they're good at it); `suggest_link_metadata` assists when wanted
+
+## Decisions
+
+### In-process endpoint, thin adapter over stores
+
+**Choice**: Mount the go-sdk Streamable HTTP handler on the existing chi router at `/mcp`; tool handlers live in `internal/mcp/` and call the same store/service methods as `internal/api` handlers.
+**Rationale**: Zero per-agent install, PAT middleware reuse, and — decisive after the review — a single implementation of visibility/ownership rules. See ADR-0018 for the full option analysis.
+**Alternatives considered**:
+- stdio subcommand as REST client: per-host install + a client-side mapping layer that can drift; rejected for v1.
+- External npm wrapper: second toolchain and artifact for a single-binary project; rejected.
+
+### Stateless JSON mode
+
+**Choice**: Run the SDK server stateless — every POST is self-contained; no server-held sessions; GET/SSE streams may 405.
+**Rationale**: Survives restarts and Caddy proxying with no affinity; v1 tools are strictly request/response, so session features buy nothing. Clients that require SSE still work through `mcp-remote`-style bridges.
+
+### Flat, verb-named tools over one mega-tool
+
+**Choice**: Eleven single-purpose tools (`create_link`, `share_link`, …) rather than a generic `golinks_api(action, payload)`.
+**Rationale**: Small, schema-typed tools are what models select reliably; input schemas double as validation; per-tool metrics fall out for free. Inventory is capped and admin verbs are excluded, keeping the blast radius of a leaked agent token at "the token owner's links" — same as the REST API.
+
+### `private` default (and `secure` when `share_with` present)
+
+**Choice**: MCP `create_link` defaults visibility to `private`; providing `share_with` without a visibility bumps the default to `secure`.
+**Rationale**: Agent-created links reference agent-produced artifacts; silently landing in the public Browse page (the REST default) is the wrong failure mode. `secure`-when-sharing follows from SPEC-0010: grants only gate secure links, so "share with Joe" only *means* something at `secure`. The divergence from REST is deliberate, documented in the spec, and confined to a default — explicit `visibility` always wins.
+**Alternatives considered**:
+- Match REST's `public` default: consistent, but wrong safety posture for autonomous writers; rejected.
+- Make visibility required: extra friction on every call for the common case; rejected.
+
+### Email as the principal reference in share/co-owner tools
+
+**Choice**: `share_with`, `share_link`, `add_co_owner` take emails, resolved against existing users; unknown emails fail the whole call atomically.
+**Rationale**: Agents know "share with joe@stump.rocks", not user UUIDs; matches the web UI's mental model. Atomic failure (no half-created link with missing grants) makes retries idempotent-ish and predictable for agents.
+
+### Error surface: tool-result errors with REST's code vocabulary
+
+**Choice**: Domain failures return MCP tool results with `isError` + `{code, message}` reusing REST codes (one casing — coordinate with the #205 casing cleanup); protocol errors only for malformed MCP or auth.
+**Rationale**: Agents recover from tool errors in-session (pick a new slug on `duplicate_slug`); protocol errors abort sessions. Shared vocabulary means one documented error table serves both surfaces.
+
+### Identity model: PAT = acting user; dedicated agent account recommended
+
+**Choice**: No new identity concept. The recommended deployment pattern (documented in the docs-site guide) is a dedicated agent user (e.g. `joestump-agent` via OIDC) holding its own PAT, so agent links have honest ownership and sharing to humans is explicit; running agents on the human's own PAT also works and makes sharing a no-op.
+**Rationale**: Reuses SPEC-0006 lifecycle (mint/revoke in UI, last-used tracking); ownership/audit stays truthful.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant A as Agent (MCP client)
+    participant M as /mcp (go-sdk, stateless)
+    participant W as PAT bearer middleware
+    participant S as Store layer (shared with /api/v1)
+    participant D as Database
+
+    A->>M: POST initialize (Bearer jl_…)
+    M->>W: authenticate
+    W-->>M: user = joestump-agent
+    M-->>A: serverInfo + tools capability
+
+    A->>M: tools/call create_link {slug, url, share_with:[joe@…]}
+    M->>W: authenticate
+    M->>S: resolve share_with emails
+    S->>D: SELECT users…
+    M->>S: tx: create link + owner + tags + share grants
+    S->>D: INSERT … (one transaction)
+    M-->>A: {short_url: https://go.stump.rocks/slug, visibility: secure}
+
+    Note over A,M: Joe opens go/slug → resolver grants access via share (SPEC-0010)
+```
+
+Component shape: `internal/mcp/` holds the server construction (tool registration, schemas, adapters) and is mounted from `internal/handler/router.go` behind the same bearer middleware used by `internal/api`. Tool adapters are ~1 store call each; anything longer belongs in the store/service layer where REST can share it.
+
+## Risks / Trade-offs
+
+- **SDK/protocol churn** (MCP spec revisions) → pinned official SDK; upgrades are routine dependency bumps; stateless mode minimizes surface.
+- **PATs in agent config files** → same exposure as any MCP server credential; mitigations are the existing lifecycle (revoke in UI, last-used visibility) and the capped, non-admin tool inventory; recommend a dedicated agent account so a leak never exposes the human's whole account.
+- **Default-visibility divergence from REST** → confined to defaults, spec'd with scenarios, and surfaced in every create result (`visibility` echoed back).
+- **Stateless mode limits future server-push features** → acceptable; revisit alongside the stdio option if subscriptions ever matter.
+- **New public route on the server** → auth evaluated before any MCP parsing; 1 MB body cap; same threat class as `/api/v1`.
+
+## Migration Plan
+
+Additive feature — no schema changes, no config required (endpoint active like `/api/v1`; `suggest_link_metadata` conditional on existing LLM config). Ships in one PR: `internal/mcp/` + router mount + integration tests + docs-site "Agents (MCP)" guide. Rollback = remove the mount.
+
+## Open Questions
+
+- Should a later revision add slug auto-generation on `create_link` (server-side slugify + collision suffix), or is `suggest_link_metadata` enough?
+- stdio subcommand (`joe-links mcp`) demand — worth shipping for offline/local-only clients?
+- If joe-links ever goes multi-tenant/public, revisit OAuth resource-server metadata (RFC 9728) for MCP-spec-compliant auth discovery.
+- Expose read-only MCP resources (`golink://recent`, `golink://mine`) once a real client workflow wants context instead of tool calls?

--- a/docs/openspec/specs/mcp-agent-access/spec.md
+++ b/docs/openspec/specs/mcp-agent-access/spec.md
@@ -1,0 +1,214 @@
+---
+status: draft
+date: 2026-07-12
+implements: [ADR-0018]
+requires: [SPEC-0006, SPEC-0010]
+---
+
+# SPEC-0018: Agent Access via MCP
+
+## Overview
+
+Exposes joe-links to AI agents over the Model Context Protocol so that agents can create, look up, and share go-links conversationally. Per ADR-0018, the MCP server is an in-process Streamable HTTP endpoint at `/mcp` inside the existing joe-links binary, implemented with the official `modelcontextprotocol/go-sdk`, authenticated with existing personal access tokens (SPEC-0006 / ADR-0009), and delegating all behavior to the same store layer as the REST API (SPEC-0005 / ADR-0008).
+
+The headline workflow: an agent holding a PAT (typically minted for a dedicated agent account) creates a link for content it produced, marks it `secure`, and shares it with a human by email — the human gets a working `go/slug` while the link never appears in public browsing (SPEC-0010).
+
+## Requirements
+
+### Requirement: MCP Endpoint
+
+The server SHALL expose a Model Context Protocol server over the Streamable HTTP transport at `/mcp`, implemented with the official `modelcontextprotocol/go-sdk`. The endpoint MUST operate statelessly: every request MUST be self-contained, the server MUST NOT require session affinity, and server-initiated streams (subscriptions, sampling) are not offered in v1. The MCP server identity (`serverInfo.name`/`version`) MUST report `joe-links` and the build version from `internal/build`.
+
+#### Scenario: Initialize handshake
+
+- **WHEN** an authenticated MCP client POSTs an `initialize` request to `/mcp`
+- **THEN** the server responds with protocol version negotiation, `serverInfo` naming `joe-links` and the build version, and a capabilities object advertising tools
+
+#### Scenario: Restart transparency
+
+- **WHEN** the joe-links process restarts between two tool calls from the same client
+- **THEN** the second call succeeds without re-initialization errors caused by server-held session state
+
+### Requirement: Bearer Token Authentication
+
+Every `/mcp` request MUST be authenticated with a personal access token presented as `Authorization: Bearer jl_…`, verified by the same middleware/token-store path as `/api/v1` (SPEC-0006). Requests without a valid token MUST receive HTTP 401 with a `WWW-Authenticate: Bearer` header and MUST NOT be dispatched to the MCP handler. Session cookies MUST be ignored by this endpoint — the Authorization header is the only accepted credential. All tool invocations SHALL act as the token's user; the endpoint MUST update the token's last-used timestamp consistently with the REST API.
+
+#### Scenario: Missing or invalid token
+
+- **WHEN** a request to `/mcp` has no Authorization header, a malformed token, or a revoked token
+- **THEN** the server responds 401 with `WWW-Authenticate: Bearer`, and no MCP message processing occurs
+
+#### Scenario: Token revocation takes immediate effect
+
+- **WHEN** a PAT used by an agent is revoked in the token management UI and the agent issues its next tool call
+- **THEN** the call fails with 401 and no tool executes
+
+#### Scenario: Cookie-bearing request
+
+- **WHEN** a request to `/mcp` carries a valid web session cookie but no Authorization header
+- **THEN** the server responds 401 exactly as if no credentials were presented
+
+### Requirement: Tool Inventory
+
+The MCP server SHALL expose the following tools, and in v1 only these tools. Each tool MUST declare a JSON Schema for its inputs, and slug/URL/visibility validation MUST be identical to the REST API's. Links MAY be referenced by `slug` or `id` wherever a link reference is accepted. Admin capabilities (user management, keyword CRUD, admin link listings) MUST NOT be exposed via MCP in v1.
+
+| Tool | Purpose | Key inputs |
+|------|---------|------------|
+| `create_link` | Create a short link | `slug` (required), `url` (required), `title`, `description`, `tags[]`, `visibility`, `share_with[]` (emails) |
+| `get_link` | Fetch one link incl. visibility, tags, owners, and (for owners of secure links) shares | `link` (slug or id) |
+| `list_links` | Search links visible to the caller | `q`, `tag`, `filter` (`mine` \| `shared` \| `public`), `cursor`, `limit` |
+| `update_link` | Modify an owned link | `link` + any of `url`, `title`, `description`, `tags[]`, `visibility` |
+| `delete_link` | Delete an owned link | `link` |
+| `share_link` | Grant a user access to a secure link | `link`, `email` |
+| `unshare_link` | Revoke a share grant | `link`, `email` |
+| `add_co_owner` | Add a co-owner by email | `link`, `email` |
+| `get_link_stats` | Click totals and recent clicks | `link`, `limit` |
+| `suggest_link_metadata` | LLM-proposed slug/title/description/tags for a URL (SPEC-0017) | `url` |
+| `list_keywords` | List keyword templates (SPEC-0008) | — |
+
+Tool results SHALL include the canonical short URL (e.g. `https://go.stump.rocks/slug`) in `create_link`, `get_link`, and `update_link` responses so agents can hand humans a working link without extra calls.
+
+#### Scenario: Tool discovery
+
+- **WHEN** an authenticated client sends `tools/list`
+- **THEN** the response contains exactly the tools above (minus `suggest_link_metadata` when no LLM is configured), each with an input schema
+
+#### Scenario: Create and hand back a working URL
+
+- **WHEN** an agent calls `create_link` with slug `retro-notes` and a destination URL
+- **THEN** the result reports success and contains the absolute short URL for `retro-notes`
+
+### Requirement: Authorization Parity with the REST API
+
+Every tool MUST enforce the same authorization rules as its corresponding `/api/v1` operation by delegating to the shared store/service layer. Tool handlers MUST NOT reimplement visibility, ownership, or share logic. Where UI and REST currently disagree, the REST behavior is normative for MCP.
+
+#### Scenario: Non-owner mutation denied
+
+- **WHEN** a caller invokes `update_link` or `delete_link` on a link they neither own nor co-own (and they are not admin)
+- **THEN** the tool returns a permission-denied error and no change occurs
+
+#### Scenario: Visibility respected in listing
+
+- **WHEN** a caller invokes `list_links` with `filter: "public"`
+- **THEN** results contain no `private` or `secure` links belonging to other users
+
+### Requirement: Agent-Oriented Creation Defaults
+
+`create_link` SHALL default `visibility` to `private` when the field is omitted. This deliberately diverges from the REST API's `public` default: agent-created links reference agent-produced content and MUST NOT appear in public browsing unless explicitly requested. When `share_with` is provided, the server MUST resolve every email to an existing user before creating the link; if any email is unknown, the tool MUST fail without creating the link and MUST name the unresolvable emails. When `share_with` is provided and `visibility` is omitted, visibility SHALL default to `secure` (a share grant is only enforced for secure links, per SPEC-0010).
+
+#### Scenario: Default is private
+
+- **WHEN** `create_link` is called without `visibility`
+- **THEN** the created link has visibility `private`
+
+#### Scenario: Share-with-me in one call
+
+- **WHEN** an agent calls `create_link` with `share_with: ["joe@stump.rocks"]` and no `visibility`
+- **THEN** the link is created with visibility `secure` and a share grant for that user, and the result contains the short URL
+
+#### Scenario: Unknown share recipient
+
+- **WHEN** `create_link` includes `share_with: ["nobody@example.com"]` and no such user exists
+- **THEN** no link is created and the error names `nobody@example.com`
+
+### Requirement: Structured Tool Errors
+
+Tool failures MUST be returned as MCP tool results flagged as errors (not protocol-level errors) carrying a stable machine-readable code plus a human-readable message. Codes MUST reuse the REST API error vocabulary (e.g. `duplicate_slug`, `not_found`, `forbidden`, `validation_failed`) with one consistent casing. Protocol-level errors are reserved for malformed MCP messages and authentication failures.
+
+#### Scenario: Duplicate slug
+
+- **WHEN** `create_link` is called with a slug that already exists
+- **THEN** the tool result is an error with code `duplicate_slug` and a message naming the slug, and the client session remains usable
+
+### Requirement: Conditional Suggestion Tool
+
+`suggest_link_metadata` MUST be registered only when an LLM provider is configured (SPEC-0017). When unregistered, it MUST NOT appear in `tools/list`.
+
+#### Scenario: No LLM configured
+
+- **WHEN** the server runs without LLM configuration and a client sends `tools/list`
+- **THEN** `suggest_link_metadata` is absent
+
+### Requirement: Observability
+
+MCP usage SHALL be observable via the existing Prometheus registry (ADR-0016): a counter labelled by tool name and outcome (`success`/`error`) MUST be incremented per tool invocation, and request logging MUST include the acting user id (never the token).
+
+#### Scenario: Tool call metrics
+
+- **WHEN** `create_link` succeeds
+- **THEN** the MCP tool-call counter for `create_link` with outcome `success` increments
+
+### Requirement: Error Handling Standards
+
+All error-producing operations MUST follow structured error handling:
+
+- Errors MUST be wrapped with contextual information at each layer boundary (e.g., "mcp create_link: resolve share recipient: user lookup failed: …")
+- Sentinel errors MUST be defined for domain-specific failure modes that callers need to distinguish programmatically
+- Silent error swallowing MUST NOT occur — every error MUST be either returned to the caller, logged with sufficient context, or explicitly handled with a documented reason for suppression
+- Structured logging MUST be used for error reporting (key-value pairs, not string interpolation)
+
+#### Scenario: Store failure surfaces cleanly
+
+- **WHEN** the database is unavailable during a `list_links` call
+- **THEN** the tool returns an error result with code `internal_error`, and the underlying cause is logged with tool name and user id context
+
+### Requirement: Database Operation Standards
+
+All database operations MUST follow structured data access patterns:
+
+- Transactions MUST be used for multi-step mutations that require atomicity — specifically, `create_link` with `share_with` MUST create the link, ownership, tags, and share grants atomically
+- Connection lifecycle MUST be explicitly managed — connections MUST be returned to the pool after use, with timeouts configured
+- Query parameters MUST use parameterized queries — string interpolation in queries MUST NOT occur
+
+#### Scenario: Atomic create-and-share
+
+- **WHEN** `create_link` with `share_with` fails while writing share grants
+- **THEN** the link, ownership, and tag writes are rolled back and no partial link exists
+
+## Security Requirements
+
+<!-- Governing: ADR-0018 (Security-by-Default), SPEC-0016 REQ "Mandatory Security Section in Web Specs" -->
+
+### Authentication
+
+All endpoints MUST require authentication by default. Public (unauthenticated) endpoints MUST be explicitly listed with justification.
+
+| Endpoint | Auth | Justification |
+|----------|------|---------------|
+| POST /mcp | Required | — |
+| GET /mcp | Required | Stateless mode; MAY respond 405 when SSE streams are not offered, but never without auth evaluation first |
+| DELETE /mcp | Required | Stateless mode; session teardown is a no-op but MUST NOT leak endpoint existence to unauthenticated callers |
+
+### Rate Limiting
+
+No application-level rate limiting in v1: the endpoint is PAT-gated, single-tenant, and fronted by Caddy on a private deployment; abuse equals a compromised token, whose remedy is revocation (SPEC-0006). This matches the existing `/api/v1` posture. If the REST API gains rate limiting, `/mcp` MUST adopt the same limits.
+
+### Security Headers
+
+All `/mcp` HTTP responses MUST include:
+
+- `Content-Security-Policy`: `default-src 'none'` (JSON/SSE responses only; nothing is rendered)
+- `X-Frame-Options`: DENY
+- `X-Content-Type-Options`: nosniff
+- `Referrer-Policy`: strict-origin-when-cross-origin
+
+### Request Body Size Limits
+
+All `/mcp` requests MUST be bounded with `http.MaxBytesReader`. Default limit: 1 MB. No tool accepts payloads that justify more.
+
+### CSRF Protection
+
+The endpoint accepts only `Authorization: Bearer` credentials and MUST ignore cookies entirely (see REQ "Bearer Token Authentication"); with no ambient credential, cross-site request forgery is not exploitable. No CSRF token is used, matching `/api/v1`.
+
+### Redirect Validation
+
+`/mcp` performs no HTTP redirects. Tool inputs containing destination URLs are stored, not followed; they are validated by the same URL validation as the REST API. Open redirects MUST NOT be introduced.
+
+## References
+
+- ADR-0018 (MCP server placement, transport, auth — implemented by this spec)
+- ADR-0008 / SPEC-0005 (REST API layer — behavioral source of truth for parity)
+- ADR-0009 / SPEC-0006 (PAT lifecycle and bearer middleware)
+- SPEC-0010 (visibility modes and share grants)
+- SPEC-0017 (LLM metadata suggestions — backing for `suggest_link_metadata`)
+- SPEC-0008 (keyword templates — backing for `list_keywords`)


### PR DESCRIPTION
## Summary

Design artifacts for agent access to joe-links over the Model Context Protocol:

- **ADR-0018** — MCP Server: in-process Streamable HTTP endpoint at `/mcp`, official `modelcontextprotocol/go-sdk`, stateless mode, PAT bearer auth; extends ADR-0008 (REST API) and ADR-0009 (PATs). Three options analyzed (in-process HTTP / stdio subcommand / external wrapper).
- **SPEC-0018: Agent Access via MCP** (`docs/openspec/specs/mcp-agent-access/`) — spec.md + design.md pair: endpoint + auth requirements, 11-tool inventory, REST authorization parity (the review's #193/#202 divergence class is designed out by construction), agent-oriented defaults (`private` by default; `share_with` on create implies `secure`), structured errors, observability, plus the mandated Security Requirements section.

Headline workflow this enables: an agent creates `go/retro-notes` as a secure link and shares it with a human by email — one tool call, working URL back.

## Planning

Sprint breakdown (epic + 3 stories) is being filed via `/sdd:plan SPEC-0018` and will reference these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).
