### PR TITLE
feat(mcp): v1 tool inventory — CRUD, sharing, stats, suggest, keywords (SPEC-0018)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -73,9 +73,39 @@ func NewHandler(deps Deps, bearer *auth.BearerTokenMiddleware) http.Handler {
 	)
 	limited := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-		streamable.ServeHTTP(w, r)
+		// Stash the request's base URL so tool handlers can build canonical
+		// short URLs (the SDK threads this context into tool calls).
+		// Governing: SPEC-0018 REQ "Tool Inventory" — short URL in results
+		ctx := context.WithValue(r.Context(), baseURLKey{}, baseURLFromRequest(r))
+		streamable.ServeHTTP(w, r.WithContext(ctx))
 	})
 	return securityHeaders(bearer.Authenticate(limited))
+}
+
+// baseURLKey is the context key for the per-request scheme://host.
+type baseURLKey struct{}
+
+// baseURLFromRequest derives scheme://host the same way the web UI's SiteURL
+// does: X-Forwarded-Proto from the reverse proxy, else TLS state.
+func baseURLFromRequest(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if xf := r.Header.Get("X-Forwarded-Proto"); xf != "" {
+		scheme = xf
+	}
+	return scheme + "://" + r.Host
+}
+
+// shortURL builds the canonical short URL for a slug from the request-scoped
+// base URL. Falls back to a bare path when no base is in context (never the
+// case for real requests).
+func shortURL(ctx context.Context, slug string) string {
+	if base, ok := ctx.Value(baseURLKey{}).(string); ok && base != "" {
+		return base + "/" + slug
+	}
+	return "/" + slug
 }
 
 // securityHeaders sets the response headers required by SPEC-0018 and adds a
@@ -109,8 +139,6 @@ func (cw *challengeWriter) WriteHeader(status int) {
 // Codes reuse the REST API vocabulary so one documented table serves both
 // surfaces.
 // Governing: SPEC-0018 REQ "Structured Tool Errors"
-//
-//nolint:unused // wired up by the SPEC-0018 tool-inventory story (#225)
 type toolError struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
@@ -119,8 +147,6 @@ type toolError struct {
 // errorResult builds an MCP tool result flagged as an error, carrying a
 // stable code plus a human-readable message as JSON text content.
 // Governing: SPEC-0018 REQ "Structured Tool Errors"
-//
-//nolint:unused // wired up by the SPEC-0018 tool-inventory story (#225)
 func errorResult(code, message string) *sdk.CallToolResult {
 	payload, err := json.Marshal(toolError{Code: code, Message: message})
 	if err != nil {
@@ -135,8 +161,6 @@ func errorResult(code, message string) *sdk.CallToolResult {
 // addTool registers a typed tool wrapped with per-call metrics and structured
 // logging. All v1 tools MUST be registered through this helper.
 // Governing: SPEC-0018 REQ "Observability", REQ "Error Handling Standards"
-//
-//nolint:unused // wired up by the SPEC-0018 tool-inventory story (#225)
 func addTool[In, Out any](s *sdk.Server, t *sdk.Tool, h sdk.ToolHandlerFor[In, Out]) {
 	sdk.AddTool(s, t, func(ctx context.Context, req *sdk.CallToolRequest, in In) (*sdk.CallToolResult, Out, error) {
 		res, out, err := h(ctx, req, in)
@@ -157,12 +181,4 @@ func addTool[In, Out any](s *sdk.Server, t *sdk.Tool, h sdk.ToolHandlerFor[In, O
 
 		return res, out, err
 	})
-}
-
-// registerTools registers the SPEC-0018 v1 tool inventory. Tools are added in
-// the tool-inventory story; the scaffold registers none.
-// Governing: SPEC-0018 REQ "Tool Inventory"
-func registerTools(s *sdk.Server, deps Deps) {
-	_ = s
-	_ = deps
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,832 @@
+// Tool inventory for the joe-links MCP server. Every tool is a thin adapter
+// over the shared store layer: authorization rules are the REST API's,
+// enforced by the same store calls — never reimplemented here.
+//
+// Governing: ADR-0018, SPEC-0018 REQ "Tool Inventory", REQ "Authorization Parity with the REST API"
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/llm"
+	"github.com/joestump/joe-links/internal/store"
+)
+
+// Error codes shared with the REST API vocabulary (one casing).
+// Governing: SPEC-0018 REQ "Structured Tool Errors"
+const (
+	codeUnauthorized   = "unauthorized"
+	codeForbidden      = "forbidden"
+	codeNotFound       = "not_found"
+	codeValidation     = "validation_failed"
+	codeDuplicateSlug  = "duplicate_slug"
+	codeUnknownUser    = "unknown_user"
+	codeDuplicateShare = "duplicate_share"
+	codeDuplicateOwner = "duplicate_owner"
+	codeLLMError       = "llm_error"
+	codeInternal       = "internal_error"
+)
+
+// ownerPayload mirrors the REST OwnerResponse shape.
+type ownerPayload struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	IsPrimary bool   `json:"is_primary"`
+}
+
+// linkPayload is the structured result for tools returning a full link.
+// ShortURL is always populated so agents can hand humans a working URL.
+// Governing: SPEC-0018 REQ "Tool Inventory" — short URL in create/get/update results
+type linkPayload struct {
+	ID          string         `json:"id"`
+	Slug        string         `json:"slug"`
+	ShortURL    string         `json:"short_url" jsonschema:"canonical short URL for this link"`
+	URL         string         `json:"url"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Visibility  string         `json:"visibility"`
+	Tags        []string       `json:"tags,omitempty"`
+	Owners      []ownerPayload `json:"owners,omitempty"`
+	SharedWith  []string       `json:"shared_with,omitempty" jsonschema:"emails with share access; only populated for owners/admins"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+}
+
+// listItemPayload is the compact per-row shape for list_links.
+type listItemPayload struct {
+	ID          string `json:"id"`
+	Slug        string `json:"slug"`
+	ShortURL    string `json:"short_url"`
+	URL         string `json:"url"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Visibility  string `json:"visibility"`
+}
+
+// registerTools registers the SPEC-0018 v1 tool inventory — exactly these
+// tools, no admin capabilities. suggest_link_metadata is registered only when
+// an LLM provider is configured.
+// Governing: SPEC-0018 REQ "Tool Inventory", REQ "Conditional Suggestion Tool"
+func registerTools(s *sdk.Server, deps Deps) {
+	addTool(s, &sdk.Tool{
+		Name:        "create_link",
+		Description: "Create a go-link. Defaults to private visibility; pass share_with emails to create a secure link shared with those users in one atomic call. Returns the working short URL.",
+	}, createLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "get_link",
+		Description: "Fetch one link by slug or id, including visibility, tags, owners, and (for owners) share grants.",
+	}, getLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "list_links",
+		Description: "List links visible to you. filter: mine (default), shared (shared with you), or public (browsable by everyone). Optional q search and tag filter apply to mine/public.",
+	}, listLinksTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "update_link",
+		Description: "Update url, title, description, tags, or visibility on a link you own. Omitted fields are left unchanged; slug is immutable.",
+	}, updateLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "delete_link",
+		Description: "Permanently delete a link you own.",
+	}, deleteLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "share_link",
+		Description: "Grant a user access to a secure link by email. The user must already have a joe-links account.",
+	}, shareLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "unshare_link",
+		Description: "Revoke a user's share access to a link by email.",
+	}, unshareLinkTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "add_co_owner",
+		Description: "Add a co-owner to a link you own, by email. Co-owners can edit and delete the link.",
+	}, addCoOwnerTool(deps))
+
+	addTool(s, &sdk.Tool{
+		Name:        "get_link_stats",
+		Description: "Click totals (all-time, 7d, 30d) and recent clicks for a link you own.",
+	}, getLinkStatsTool(deps))
+
+	// Governing: SPEC-0018 REQ "Conditional Suggestion Tool"
+	if deps.Suggester != nil {
+		addTool(s, &sdk.Tool{
+			Name:        "suggest_link_metadata",
+			Description: "Ask the configured LLM to suggest a slug, title, description, and tags for a destination URL.",
+		}, suggestTool(deps))
+	}
+
+	addTool(s, &sdk.Tool{
+		Name:        "list_keywords",
+		Description: "List keyword templates configured on this server (used for keyword host routing like jira/ABC-123).",
+	}, listKeywordsTool(deps))
+}
+
+// --- shared helpers -------------------------------------------------------
+
+// requireUser returns the authenticated user from the request context. The
+// bearer middleware guarantees presence; the nil check is defense in depth.
+// Governing: SPEC-0018 REQ "Bearer Token Authentication"
+func requireUser(ctx context.Context) (*store.User, *sdk.CallToolResult) {
+	if u := auth.UserFromContext(ctx); u != nil {
+		return u, nil
+	}
+	return nil, errorResult(codeUnauthorized, "no authenticated user in request context")
+}
+
+// resolveLink looks a link up by slug first, then by id.
+func resolveLink(ctx context.Context, deps Deps, ref string) (*store.Link, *sdk.CallToolResult) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, errorResult(codeValidation, "link reference (slug or id) is required")
+	}
+	link, err := deps.LinkStore.GetBySlug(ctx, ref)
+	if err == nil {
+		return link, nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		slog.Error("mcp: resolve link by slug", "ref", ref, "error", err)
+		return nil, errorResult(codeInternal, "failed to look up link")
+	}
+	link, err = deps.LinkStore.GetByID(ctx, ref)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrNotFound) {
+			return nil, errorResult(codeNotFound, fmt.Sprintf("no link with slug or id %q", ref))
+		}
+		slog.Error("mcp: resolve link by id", "ref", ref, "error", err)
+		return nil, errorResult(codeInternal, "failed to look up link")
+	}
+	return link, nil
+}
+
+// isOwnerOrAdmin mirrors the REST mutation rule: link owners (incl. co-owners)
+// and admins.
+// Governing: SPEC-0018 REQ "Authorization Parity with the REST API"
+func isOwnerOrAdmin(deps Deps, user *store.User, linkID string) (bool, error) {
+	if user.Role == "admin" {
+		return true, nil
+	}
+	return deps.OwnershipStore.IsOwner(linkID, user.ID)
+}
+
+// canRead mirrors REST GET /links/{id}: owner OR share recipient OR admin.
+// Governing: SPEC-0018 REQ "Authorization Parity with the REST API"
+func canRead(ctx context.Context, deps Deps, user *store.User, linkID string) (bool, error) {
+	ok, err := isOwnerOrAdmin(deps, user, linkID)
+	if err != nil || ok {
+		return ok, err
+	}
+	return deps.LinkStore.HasShare(ctx, linkID, user.ID)
+}
+
+// buildLinkPayload assembles the full link result, including owners and — for
+// owners/admins — the share list resolved to emails.
+func buildLinkPayload(ctx context.Context, deps Deps, link *store.Link, includeShares bool) (*linkPayload, error) {
+	p := &linkPayload{
+		ID:          link.ID,
+		Slug:        link.Slug,
+		ShortURL:    shortURL(ctx, link.Slug),
+		URL:         link.URL,
+		Title:       link.Title,
+		Description: link.Description,
+		Visibility:  link.Visibility,
+		CreatedAt:   link.CreatedAt,
+		UpdatedAt:   link.UpdatedAt,
+	}
+
+	tags, err := deps.LinkStore.ListTags(ctx, link.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	for _, t := range tags {
+		p.Tags = append(p.Tags, t.Name)
+	}
+
+	owners, err := deps.OwnershipStore.ListOwnerUsers(link.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list owners: %w", err)
+	}
+	for _, o := range owners {
+		p.Owners = append(p.Owners, ownerPayload{ID: o.ID, Email: o.Email, IsPrimary: o.IsPrimary})
+	}
+
+	if includeShares {
+		shares, err := deps.LinkStore.ListShares(ctx, link.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list shares: %w", err)
+		}
+		for _, sh := range shares {
+			u, err := deps.UserStore.GetByID(ctx, sh.UserID)
+			if err != nil {
+				continue // dangling share row; skip rather than fail the read
+			}
+			p.SharedWith = append(p.SharedWith, u.Email)
+		}
+		sort.Strings(p.SharedWith)
+	}
+	return p, nil
+}
+
+// resolveEmails maps share_with emails to user IDs. All emails must resolve;
+// unknown ones fail the whole call, named.
+// Governing: SPEC-0018 REQ "Agent-Oriented Creation Defaults"
+func resolveEmails(ctx context.Context, deps Deps, emails []string) ([]string, *sdk.CallToolResult) {
+	ids := make([]string, 0, len(emails))
+	var unknown []string
+	for _, e := range emails {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		u, err := deps.UserStore.GetByEmail(ctx, e)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				unknown = append(unknown, e)
+				continue
+			}
+			slog.Error("mcp: resolve email", "error", err)
+			return nil, errorResult(codeInternal, "failed to resolve user email")
+		}
+		ids = append(ids, u.ID)
+	}
+	if len(unknown) > 0 {
+		return nil, errorResult(codeUnknownUser,
+			fmt.Sprintf("no joe-links account for: %s — users must sign in once before links can be shared with them", strings.Join(unknown, ", ")))
+	}
+	return ids, nil
+}
+
+func internalError(action string, err error) *sdk.CallToolResult {
+	slog.Error("mcp: "+action, "error", err)
+	return errorResult(codeInternal, action+" failed")
+}
+
+// --- create_link ----------------------------------------------------------
+
+type createLinkIn struct {
+	Slug        string   `json:"slug" jsonschema:"short slug, [a-z0-9][a-z0-9-]*[a-z0-9]"`
+	URL         string   `json:"url" jsonschema:"destination URL; may contain $variable placeholders"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Visibility  string   `json:"visibility,omitempty" jsonschema:"public, private, or secure; defaults to private (secure when share_with is set)"`
+	ShareWith   []string `json:"share_with,omitempty" jsonschema:"emails of existing users to grant access; implies secure visibility unless overridden"`
+}
+
+func createLinkTool(deps Deps) sdk.ToolHandlerFor[createLinkIn, *linkPayload] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in createLinkIn) (*sdk.CallToolResult, *linkPayload, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+
+		if strings.TrimSpace(in.URL) == "" {
+			return errorResult(codeValidation, "url is required"), nil, nil
+		}
+		if err := store.ValidateSlugFormat(in.Slug); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+		if err := store.ValidateURLVariables(in.URL); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+		if err := store.ValidateLinkText(in.Title, in.Description); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+
+		// Agent-surface defaults: private unless sharing, which implies secure.
+		// Explicit visibility always wins. Deliberate divergence from the REST
+		// default of public — see SPEC-0018.
+		// Governing: SPEC-0018 REQ "Agent-Oriented Creation Defaults"
+		visibility := in.Visibility
+		if visibility == "" {
+			if len(in.ShareWith) > 0 {
+				visibility = "secure"
+			} else {
+				visibility = "private"
+			}
+		}
+		if err := store.ValidateVisibility(visibility); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+
+		shareIDs, denied := resolveEmails(ctx, deps, in.ShareWith)
+		if denied != nil {
+			return denied, nil, nil
+		}
+
+		// Atomic: link + owner + tags + shares in one transaction.
+		// Governing: SPEC-0018 REQ "Database Operation Standards"
+		link, err := deps.LinkStore.CreateFull(ctx, in.Slug, in.URL, user.ID, in.Title, in.Description, visibility, in.Tags, shareIDs, user.ID)
+		if err != nil {
+			if errors.Is(err, store.ErrSlugTaken) {
+				return errorResult(codeDuplicateSlug, fmt.Sprintf("slug %q already exists", in.Slug)), nil, nil
+			}
+			return internalError("create link", err), nil, nil
+		}
+
+		p, err := buildLinkPayload(ctx, deps, link, true)
+		if err != nil {
+			return internalError("build link result", err), nil, nil
+		}
+		return nil, p, nil
+	}
+}
+
+// --- get_link ---------------------------------------------------------------
+
+type linkRefIn struct {
+	Link string `json:"link" jsonschema:"link slug or id"`
+}
+
+func getLinkTool(deps Deps) sdk.ToolHandlerFor[linkRefIn, *linkPayload] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in linkRefIn) (*sdk.CallToolResult, *linkPayload, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+		link, errRes := resolveLink(ctx, deps, in.Link)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+
+		ok, err := canRead(ctx, deps, user, link.ID)
+		if err != nil {
+			return internalError("authorize read", err), nil, nil
+		}
+		if !ok {
+			return errorResult(codeForbidden, "you do not have access to this link"), nil, nil
+		}
+
+		owner, err := isOwnerOrAdmin(deps, user, link.ID)
+		if err != nil {
+			return internalError("authorize read", err), nil, nil
+		}
+		p, err := buildLinkPayload(ctx, deps, link, owner)
+		if err != nil {
+			return internalError("build link result", err), nil, nil
+		}
+		return nil, p, nil
+	}
+}
+
+// --- list_links ---------------------------------------------------------------
+
+type listLinksIn struct {
+	Q      string `json:"q,omitempty" jsonschema:"search slugs, URLs, titles, and descriptions"`
+	Tag    string `json:"tag,omitempty" jsonschema:"filter by tag slug (mine filter only)"`
+	Filter string `json:"filter,omitempty" jsonschema:"mine (default), shared, or public"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"max results, default 50, cap 200"`
+}
+
+type listLinksOut struct {
+	Links []listItemPayload `json:"links"`
+	Count int               `json:"count"`
+}
+
+func listLinksTool(deps Deps) sdk.ToolHandlerFor[listLinksIn, *listLinksOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in listLinksIn) (*sdk.CallToolResult, *listLinksOut, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+
+		limit := in.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 200 {
+			limit = 200
+		}
+
+		out := &listLinksOut{Links: []listItemPayload{}}
+		appendLink := func(id, slug, url, title, description, visibility string) {
+			out.Links = append(out.Links, listItemPayload{
+				ID: id, Slug: slug, ShortURL: shortURL(ctx, slug),
+				URL: url, Title: title, Description: description, Visibility: visibility,
+			})
+		}
+
+		switch in.Filter {
+		case "", "mine":
+			var links []*store.Link
+			var err error
+			switch {
+			case in.Q != "":
+				links, err = deps.LinkStore.SearchByOwner(ctx, user.ID, in.Q)
+			case in.Tag != "":
+				links, err = deps.LinkStore.ListByOwnerAndTag(ctx, user.ID, in.Tag)
+			default:
+				links, err = deps.LinkStore.ListByOwner(ctx, user.ID)
+			}
+			if err != nil {
+				return internalError("list links", err), nil, nil
+			}
+			for _, l := range links {
+				if len(out.Links) >= limit {
+					break
+				}
+				appendLink(l.ID, l.Slug, l.URL, l.Title, l.Description, l.Visibility)
+			}
+		case "shared":
+			links, err := deps.LinkStore.ListSharedWithUser(ctx, user.ID)
+			if err != nil {
+				return internalError("list shared links", err), nil, nil
+			}
+			for _, l := range links {
+				if len(out.Links) >= limit {
+					break
+				}
+				appendLink(l.ID, l.Slug, l.URL, l.Title, l.Description, l.Visibility)
+			}
+		case "public":
+			// Governing: SPEC-0018 REQ "Authorization Parity with the REST API"
+			// — public listing never exposes other users' private/secure links.
+			links, _, err := deps.LinkStore.ListPublic(ctx, user.ID, in.Q, 1, limit)
+			if err != nil {
+				return internalError("list public links", err), nil, nil
+			}
+			for _, l := range links {
+				appendLink(l.ID, l.Slug, l.URL, l.Title, l.Description, l.Visibility)
+			}
+		default:
+			return errorResult(codeValidation, `filter must be "mine", "shared", or "public"`), nil, nil
+		}
+
+		out.Count = len(out.Links)
+		return nil, out, nil
+	}
+}
+
+// --- update_link ---------------------------------------------------------------
+
+type updateLinkIn struct {
+	Link        string    `json:"link" jsonschema:"link slug or id"`
+	URL         *string   `json:"url,omitempty"`
+	Title       *string   `json:"title,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" jsonschema:"replaces the full tag set; [] clears all tags"`
+	Visibility  *string   `json:"visibility,omitempty" jsonschema:"public, private, or secure"`
+}
+
+func updateLinkTool(deps Deps) sdk.ToolHandlerFor[updateLinkIn, *linkPayload] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in updateLinkIn) (*sdk.CallToolResult, *linkPayload, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+		link, errRes := resolveLink(ctx, deps, in.Link)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		ok, err := isOwnerOrAdmin(deps, user, link.ID)
+		if err != nil {
+			return internalError("authorize update", err), nil, nil
+		}
+		if !ok {
+			return errorResult(codeForbidden, "only owners and admins may update a link"), nil, nil
+		}
+
+		// Overlay provided fields on current values; omitted fields unchanged.
+		url, title, description, visibility := link.URL, link.Title, link.Description, link.Visibility
+		if in.URL != nil {
+			url = *in.URL
+		}
+		if in.Title != nil {
+			title = *in.Title
+		}
+		if in.Description != nil {
+			description = *in.Description
+		}
+		if in.Visibility != nil {
+			visibility = *in.Visibility
+		}
+		if strings.TrimSpace(url) == "" {
+			return errorResult(codeValidation, "url cannot be empty"), nil, nil
+		}
+		if err := store.ValidateURLVariables(url); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+		if err := store.ValidateLinkText(title, description); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+		if err := store.ValidateVisibility(visibility); err != nil {
+			return errorResult(codeValidation, err.Error()), nil, nil
+		}
+
+		updated, err := deps.LinkStore.Update(ctx, link.ID, url, title, description, visibility)
+		if err != nil {
+			return internalError("update link", err), nil, nil
+		}
+
+		if in.Tags != nil {
+			// Dedupe case-insensitively so duplicate spellings cannot roll the
+			// tag write back (tags upsert by derived slug).
+			seen := map[string]bool{}
+			var tags []string
+			for _, tag := range *in.Tags {
+				k := strings.ToLower(strings.TrimSpace(tag))
+				if k == "" || seen[k] {
+					continue
+				}
+				seen[k] = true
+				tags = append(tags, tag)
+			}
+			if err := deps.LinkStore.SetTags(ctx, updated.ID, tags); err != nil {
+				return internalError("update tags", err), nil, nil
+			}
+		}
+
+		p, err := buildLinkPayload(ctx, deps, updated, true)
+		if err != nil {
+			return internalError("build link result", err), nil, nil
+		}
+		return nil, p, nil
+	}
+}
+
+// --- delete_link ---------------------------------------------------------------
+
+type deleteLinkOut struct {
+	Deleted bool   `json:"deleted"`
+	Slug    string `json:"slug"`
+}
+
+func deleteLinkTool(deps Deps) sdk.ToolHandlerFor[linkRefIn, *deleteLinkOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in linkRefIn) (*sdk.CallToolResult, *deleteLinkOut, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+		link, errRes := resolveLink(ctx, deps, in.Link)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		ok, err := isOwnerOrAdmin(deps, user, link.ID)
+		if err != nil {
+			return internalError("authorize delete", err), nil, nil
+		}
+		if !ok {
+			return errorResult(codeForbidden, "only owners and admins may delete a link"), nil, nil
+		}
+		if err := deps.LinkStore.Delete(ctx, link.ID); err != nil {
+			return internalError("delete link", err), nil, nil
+		}
+		return nil, &deleteLinkOut{Deleted: true, Slug: link.Slug}, nil
+	}
+}
+
+// --- share_link / unshare_link / add_co_owner ---------------------------------
+
+type shareIn struct {
+	Link  string `json:"link" jsonschema:"link slug or id"`
+	Email string `json:"email" jsonschema:"email of an existing joe-links user"`
+}
+
+type shareOut struct {
+	Link       string   `json:"link"`
+	SharedWith []string `json:"shared_with"`
+}
+
+// requireShareTarget resolves the link + target user and checks owner/admin.
+func requireShareTarget(ctx context.Context, deps Deps, in shareIn) (*store.Link, *store.User, *sdk.CallToolResult) {
+	user, denied := requireUser(ctx)
+	if denied != nil {
+		return nil, nil, denied
+	}
+	link, errRes := resolveLink(ctx, deps, in.Link)
+	if errRes != nil {
+		return nil, nil, errRes
+	}
+	ok, err := isOwnerOrAdmin(deps, user, link.ID)
+	if err != nil {
+		return nil, nil, internalError("authorize share management", err)
+	}
+	if !ok {
+		return nil, nil, errorResult(codeForbidden, "only owners and admins may manage shares")
+	}
+	target, err := deps.UserStore.GetByEmail(ctx, strings.TrimSpace(in.Email))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, errorResult(codeUnknownUser,
+				fmt.Sprintf("no joe-links account for %s — users must sign in once before links can be shared with them", in.Email))
+		}
+		return nil, nil, internalError("resolve user email", err)
+	}
+	return link, target, nil
+}
+
+func sharesResult(ctx context.Context, deps Deps, link *store.Link) (*sdk.CallToolResult, *shareOut, error) {
+	p, err := buildLinkPayload(ctx, deps, link, true)
+	if err != nil {
+		return internalError("list shares", err), nil, nil
+	}
+	shared := p.SharedWith
+	if shared == nil {
+		shared = []string{}
+	}
+	return nil, &shareOut{Link: link.Slug, SharedWith: shared}, nil
+}
+
+func shareLinkTool(deps Deps) sdk.ToolHandlerFor[shareIn, *shareOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in shareIn) (*sdk.CallToolResult, *shareOut, error) {
+		user := auth.UserFromContext(ctx)
+		link, target, errRes := requireShareTarget(ctx, deps, in)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		has, err := deps.LinkStore.HasShare(ctx, link.ID, target.ID)
+		if err != nil {
+			return internalError("check existing share", err), nil, nil
+		}
+		if has {
+			return errorResult(codeDuplicateShare, fmt.Sprintf("%s already has access to %s", in.Email, link.Slug)), nil, nil
+		}
+		if err := deps.LinkStore.AddShare(ctx, link.ID, target.ID, user.ID); err != nil {
+			return internalError("add share", err), nil, nil
+		}
+		return sharesResult(ctx, deps, link)
+	}
+}
+
+func unshareLinkTool(deps Deps) sdk.ToolHandlerFor[shareIn, *shareOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in shareIn) (*sdk.CallToolResult, *shareOut, error) {
+		link, target, errRes := requireShareTarget(ctx, deps, in)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		if err := deps.LinkStore.RemoveShare(ctx, link.ID, target.ID); err != nil {
+			return internalError("remove share", err), nil, nil
+		}
+		return sharesResult(ctx, deps, link)
+	}
+}
+
+type coOwnerOut struct {
+	Link   string         `json:"link"`
+	Owners []ownerPayload `json:"owners"`
+}
+
+func addCoOwnerTool(deps Deps) sdk.ToolHandlerFor[shareIn, *coOwnerOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in shareIn) (*sdk.CallToolResult, *coOwnerOut, error) {
+		link, target, errRes := requireShareTarget(ctx, deps, in)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		if err := deps.LinkStore.AddOwner(ctx, link.ID, target.ID); err != nil {
+			if errors.Is(err, store.ErrDuplicateOwner) || errors.Is(err, store.ErrAlreadyOwner) {
+				return errorResult(codeDuplicateOwner, fmt.Sprintf("%s already owns %s", in.Email, link.Slug)), nil, nil
+			}
+			return internalError("add co-owner", err), nil, nil
+		}
+		p, err := buildLinkPayload(ctx, deps, link, false)
+		if err != nil {
+			return internalError("list owners", err), nil, nil
+		}
+		return nil, &coOwnerOut{Link: link.Slug, Owners: p.Owners}, nil
+	}
+}
+
+// --- get_link_stats -------------------------------------------------------------
+
+type statsIn struct {
+	Link  string `json:"link" jsonschema:"link slug or id"`
+	Limit int    `json:"limit,omitempty" jsonschema:"max recent clicks, default 20, cap 100"`
+}
+
+type recentClickPayload struct {
+	ClickedAt time.Time `json:"clicked_at"`
+	Referrer  string    `json:"referrer,omitempty"`
+	User      string    `json:"user,omitempty" jsonschema:"display name of the authenticated clicker, empty for anonymous"`
+}
+
+type statsOut struct {
+	Link    string               `json:"link"`
+	Total   int64                `json:"total"`
+	Last7d  int64                `json:"last_7d"`
+	Last30d int64                `json:"last_30d"`
+	Recent  []recentClickPayload `json:"recent"`
+}
+
+func getLinkStatsTool(deps Deps) sdk.ToolHandlerFor[statsIn, *statsOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in statsIn) (*sdk.CallToolResult, *statsOut, error) {
+		user, denied := requireUser(ctx)
+		if denied != nil {
+			return denied, nil, nil
+		}
+		link, errRes := resolveLink(ctx, deps, in.Link)
+		if errRes != nil {
+			return errRes, nil, nil
+		}
+		// REST stats rule: owners and admins only.
+		// Governing: SPEC-0018 REQ "Authorization Parity with the REST API"
+		ok, err := isOwnerOrAdmin(deps, user, link.ID)
+		if err != nil {
+			return internalError("authorize stats", err), nil, nil
+		}
+		if !ok {
+			return errorResult(codeForbidden, "only owners and admins may view stats"), nil, nil
+		}
+
+		limit := in.Limit
+		if limit <= 0 {
+			limit = 20
+		}
+		if limit > 100 {
+			limit = 100
+		}
+
+		stats, err := deps.ClickStore.GetClickStats(ctx, link.ID)
+		if err != nil {
+			return internalError("load click stats", err), nil, nil
+		}
+		recent, err := deps.ClickStore.ListRecentClicks(ctx, link.ID, limit)
+		if err != nil {
+			return internalError("load recent clicks", err), nil, nil
+		}
+
+		out := &statsOut{Link: link.Slug, Total: stats.Total, Last7d: stats.Last7d, Last30d: stats.Last30d, Recent: []recentClickPayload{}}
+		for _, c := range recent {
+			out.Recent = append(out.Recent, recentClickPayload{ClickedAt: c.ClickedAt, Referrer: c.Referrer, User: c.DisplayName})
+		}
+		return nil, out, nil
+	}
+}
+
+// --- suggest_link_metadata -------------------------------------------------------
+
+type suggestIn struct {
+	URL string `json:"url" jsonschema:"destination URL to suggest metadata for"`
+}
+
+type suggestOut struct {
+	Slug        string   `json:"slug,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+func suggestTool(deps Deps) sdk.ToolHandlerFor[suggestIn, *suggestOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, in suggestIn) (*sdk.CallToolResult, *suggestOut, error) {
+		if _, denied := requireUser(ctx); denied != nil {
+			return denied, nil, nil
+		}
+		if strings.TrimSpace(in.URL) == "" {
+			return errorResult(codeValidation, "url is required"), nil, nil
+		}
+		resp, err := deps.Suggester.Suggest(ctx, llm.SuggestRequest{URL: in.URL})
+		if err != nil {
+			var malformed *llm.MalformedResponseError
+			if errors.As(err, &malformed) {
+				slog.Error("mcp: LLM suggest malformed response", "error", malformed.Err)
+			} else {
+				slog.Error("mcp: LLM suggest", "error", err)
+			}
+			return errorResult(codeLLMError, "LLM provider error"), nil, nil
+		}
+		// Mirror the REST behavior: blank out invalid slugs, keep the rest.
+		// Governing: SPEC-0017 REQ "Default Prompt Template"
+		slug := resp.Slug
+		if slug != "" && store.ValidateSlugFormat(slug) != nil {
+			slug = ""
+		}
+		return nil, &suggestOut{Slug: slug, Title: resp.Title, Description: resp.Description, Tags: resp.Tags}, nil
+	}
+}
+
+// --- list_keywords ----------------------------------------------------------------
+
+type keywordsOut struct {
+	Keywords []string `json:"keywords"`
+}
+
+func listKeywordsTool(deps Deps) sdk.ToolHandlerFor[any, *keywordsOut] {
+	return func(ctx context.Context, req *sdk.CallToolRequest, _ any) (*sdk.CallToolResult, *keywordsOut, error) {
+		if _, denied := requireUser(ctx); denied != nil {
+			return denied, nil, nil
+		}
+		list, err := deps.KeywordStore.List(ctx)
+		if err != nil {
+			return internalError("list keywords", err), nil, nil
+		}
+		out := &keywordsOut{Keywords: []string{}}
+		for _, k := range list {
+			out.Keywords = append(out.Keywords, k.Keyword)
+		}
+		return nil, out, nil
+	}
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1,0 +1,654 @@
+// Governing: ADR-0018, SPEC-0018 REQ "Tool Inventory", REQ "Agent-Oriented Creation Defaults",
+// REQ "Database Operation Standards", REQ "Observability"
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/joestump/joe-links/internal/auth"
+	"github.com/joestump/joe-links/internal/llm"
+	"github.com/joestump/joe-links/internal/mcp"
+	"github.com/joestump/joe-links/internal/metrics"
+	"github.com/joestump/joe-links/internal/store"
+	jltestutil "github.com/joestump/joe-links/internal/testutil"
+)
+
+// fullEnv extends testEnv with every store, for tool tests.
+type fullEnv struct {
+	Handler      http.Handler
+	LinkStore    *store.LinkStore
+	TagStore     *store.TagStore
+	Ownership    *store.OwnershipStore
+	UserStore    *store.UserStore
+	TokenStore   *auth.SQLTokenStore
+	KeywordStore *store.KeywordStore
+	ClickStore   *store.ClickStore
+}
+
+func newFullEnv(t *testing.T, suggester llm.Suggester) *fullEnv {
+	t.Helper()
+	db := jltestutil.NewTestDB(t)
+
+	owns := store.NewOwnershipStore(db)
+	tags := store.NewTagStore(db)
+	ls := store.NewLinkStore(db, owns, tags)
+	us := store.NewUserStore(db)
+	ts := auth.NewSQLTokenStore(db)
+	ks := store.NewKeywordStore(db)
+	cs := store.NewClickStore(db)
+
+	bearer := auth.NewBearerTokenMiddleware(ts, us)
+	h := mcp.NewHandler(mcp.Deps{
+		LinkStore:      ls,
+		OwnershipStore: owns,
+		TagStore:       tags,
+		UserStore:      us,
+		KeywordStore:   ks,
+		ClickStore:     cs,
+		Suggester:      suggester,
+	}, bearer)
+
+	return &fullEnv{Handler: h, LinkStore: ls, TagStore: tags, Ownership: owns, UserStore: us, TokenStore: ts, KeywordStore: ks, ClickStore: cs}
+}
+
+func seedUserToken(t *testing.T, env *fullEnv, email string) (*store.User, string) {
+	t.Helper()
+	ctx := context.Background()
+	u, err := env.UserStore.Upsert(ctx, "test", "sub-"+email, email, "User "+email, "user")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	plaintext, hash, err := auth.GenerateToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	if _, err := env.TokenStore.Create(ctx, u.ID, "t", hash, nil); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	return u, plaintext
+}
+
+// toolResponse is the parsed result of a tools/call.
+type toolResponse struct {
+	IsError    bool
+	Structured map[string]any
+	ErrCode    string
+	ErrMessage string
+	Raw        map[string]any
+}
+
+// callTool posts a tools/call and parses the result envelope.
+func callTool(t *testing.T, env *fullEnv, token, name string, args map[string]any) *toolResponse {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Host = "go.example.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	env.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("tools/call %s: HTTP %d: %s", name, rec.Code, rec.Body.String())
+	}
+
+	var envlp struct {
+		Result map[string]any  `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envlp); err != nil {
+		t.Fatalf("parse response: %v\n%s", err, rec.Body.String())
+	}
+	if len(envlp.Error) > 0 {
+		t.Fatalf("JSON-RPC error calling %s: %s", name, envlp.Error)
+	}
+
+	resp := &toolResponse{Raw: envlp.Result}
+	resp.IsError, _ = envlp.Result["isError"].(bool)
+	resp.Structured, _ = envlp.Result["structuredContent"].(map[string]any)
+	if resp.IsError {
+		if contents, ok := envlp.Result["content"].([]any); ok && len(contents) > 0 {
+			if c0, ok := contents[0].(map[string]any); ok {
+				if text, ok := c0["text"].(string); ok {
+					var te struct {
+						Code    string `json:"code"`
+						Message string `json:"message"`
+					}
+					if err := json.Unmarshal([]byte(text), &te); err == nil {
+						resp.ErrCode, resp.ErrMessage = te.Code, te.Message
+					} else {
+						resp.ErrMessage = text
+					}
+				}
+			}
+		}
+	}
+	return resp
+}
+
+func toolNames(t *testing.T, env *fullEnv, token string) []string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	env.Handler.ServeHTTP(rec, req)
+	var envlp struct {
+		Result struct {
+			Tools []struct {
+				Name        string         `json:"name"`
+				InputSchema map[string]any `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envlp); err != nil {
+		t.Fatalf("parse tools/list: %v", err)
+	}
+	names := make([]string, 0, len(envlp.Result.Tools))
+	for _, tool := range envlp.Result.Tools {
+		if tool.InputSchema == nil {
+			t.Errorf("tool %s has no input schema", tool.Name)
+		}
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+// Governing: SPEC-0018 REQ "Tool Inventory"
+// Scenario: Tool discovery
+func TestToolInventory(t *testing.T) {
+	base := []string{
+		"create_link", "get_link", "list_links", "update_link", "delete_link",
+		"share_link", "unshare_link", "add_co_owner", "get_link_stats", "list_keywords",
+	}
+
+	t.Run("without LLM", func(t *testing.T) {
+		env := newFullEnv(t, nil)
+		_, token := seedUserToken(t, env, "a@example.com")
+		got := toolNames(t, env, token)
+		want := map[string]bool{}
+		for _, n := range base {
+			want[n] = true
+		}
+		if len(got) != len(base) {
+			t.Fatalf("tools = %v, want exactly %v", got, base)
+		}
+		for _, n := range got {
+			if !want[n] {
+				t.Errorf("unexpected tool %s", n)
+			}
+		}
+		for _, n := range got {
+			if n == "suggest_link_metadata" {
+				t.Error("suggest_link_metadata must be absent without LLM config")
+			}
+		}
+	})
+
+	t.Run("with LLM", func(t *testing.T) {
+		env := newFullEnv(t, fakeSuggester{})
+		_, token := seedUserToken(t, env, "a@example.com")
+		got := toolNames(t, env, token)
+		if len(got) != len(base)+1 {
+			t.Fatalf("tools = %v, want %d incl. suggest_link_metadata", got, len(base)+1)
+		}
+		found := false
+		for _, n := range got {
+			if n == "suggest_link_metadata" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("suggest_link_metadata missing with LLM configured")
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Agent-Oriented Creation Defaults"
+// Scenarios: Default is private / Share-with-me in one call / Unknown share recipient
+func TestCreateLinkDefaultsAndSharing(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "agent@example.com")
+	joe, _ := seedUserToken(t, env, "joe@example.com")
+
+	t.Run("default is private with short URL", func(t *testing.T) {
+		resp := callTool(t, env, token, "create_link", map[string]any{
+			"slug": "retro-notes", "url": "https://example.com/retro",
+		})
+		if resp.IsError {
+			t.Fatalf("unexpected error: %s %s", resp.ErrCode, resp.ErrMessage)
+		}
+		if v := resp.Structured["visibility"]; v != "private" {
+			t.Errorf("visibility = %v, want private", v)
+		}
+		if su := resp.Structured["short_url"]; su != "http://go.example.com/retro-notes" {
+			t.Errorf("short_url = %v", su)
+		}
+	})
+
+	t.Run("share_with implies secure and grants access", func(t *testing.T) {
+		resp := callTool(t, env, token, "create_link", map[string]any{
+			"slug": "shared-doc", "url": "https://example.com/doc",
+			"share_with": []string{"joe@example.com"},
+		})
+		if resp.IsError {
+			t.Fatalf("unexpected error: %s %s", resp.ErrCode, resp.ErrMessage)
+		}
+		if v := resp.Structured["visibility"]; v != "secure" {
+			t.Errorf("visibility = %v, want secure", v)
+		}
+		shared, _ := resp.Structured["shared_with"].([]any)
+		if len(shared) != 1 || shared[0] != "joe@example.com" {
+			t.Errorf("shared_with = %v", shared)
+		}
+		link, err := env.LinkStore.GetBySlug(context.Background(), "shared-doc")
+		if err != nil {
+			t.Fatalf("link not created: %v", err)
+		}
+		has, err := env.LinkStore.HasShare(context.Background(), link.ID, joe.ID)
+		if err != nil || !has {
+			t.Errorf("share grant missing (has=%v err=%v)", has, err)
+		}
+	})
+
+	t.Run("unknown share recipient fails atomically", func(t *testing.T) {
+		resp := callTool(t, env, token, "create_link", map[string]any{
+			"slug": "doomed", "url": "https://example.com/x",
+			"share_with": []string{"nobody@example.com"},
+		})
+		if !resp.IsError || resp.ErrCode != "unknown_user" {
+			t.Fatalf("want unknown_user error, got isError=%v code=%s", resp.IsError, resp.ErrCode)
+		}
+		if !strings.Contains(resp.ErrMessage, "nobody@example.com") {
+			t.Errorf("error must name the unknown email: %s", resp.ErrMessage)
+		}
+		if _, err := env.LinkStore.GetBySlug(context.Background(), "doomed"); !errors.Is(err, store.ErrNotFound) {
+			t.Errorf("link must not exist after failed share resolution, got err=%v", err)
+		}
+	})
+
+	t.Run("duplicate slug", func(t *testing.T) {
+		resp := callTool(t, env, token, "create_link", map[string]any{
+			"slug": "retro-notes", "url": "https://example.com/other",
+		})
+		if !resp.IsError || resp.ErrCode != "duplicate_slug" {
+			t.Fatalf("want duplicate_slug, got isError=%v code=%s", resp.IsError, resp.ErrCode)
+		}
+	})
+
+	t.Run("validation errors", func(t *testing.T) {
+		for name, args := range map[string]map[string]any{
+			"bad slug":      {"slug": "Bad_Slug", "url": "https://example.com"},
+			"reserved slug": {"slug": "mcp", "url": "https://example.com"},
+			"empty url":     {"slug": "ok-slug", "url": ""},
+			"dup variable":  {"slug": "ok-slug2", "url": "https://x.com/$a/$a"},
+			"bad viz":       {"slug": "ok-slug3", "url": "https://x.com", "visibility": "sneaky"},
+		} {
+			resp := callTool(t, env, token, "create_link", args)
+			if !resp.IsError || resp.ErrCode != "validation_failed" {
+				t.Errorf("%s: want validation_failed, got isError=%v code=%s", name, resp.IsError, resp.ErrCode)
+			}
+		}
+	})
+
+	// Governing: SPEC-0018 REQ "Observability" — scenario: Tool call metrics
+	t.Run("metrics counted", func(t *testing.T) {
+		if got := testutil.ToFloat64(metrics.MCPToolCallsTotal.WithLabelValues("create_link", "success")); got < 2 {
+			t.Errorf("create_link success counter = %v, want >= 2", got)
+		}
+		if got := testutil.ToFloat64(metrics.MCPToolCallsTotal.WithLabelValues("create_link", "error")); got < 1 {
+			t.Errorf("create_link error counter = %v, want >= 1", got)
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Tool Inventory" — get/update/delete round trip.
+func TestLinkLifecycleTools(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "agent@example.com")
+	_, otherToken := seedUserToken(t, env, "other@example.com")
+
+	created := callTool(t, env, token, "create_link", map[string]any{
+		"slug": "life", "url": "https://example.com/1", "title": "One",
+		"tags": []string{"Jira", "jira", "ops"}, "visibility": "public",
+	})
+	if created.IsError {
+		t.Fatalf("create: %s %s", created.ErrCode, created.ErrMessage)
+	}
+	tags, _ := created.Structured["tags"].([]any)
+	if len(tags) != 2 {
+		t.Errorf("duplicate tag spellings must collapse: tags = %v", tags)
+	}
+
+	t.Run("get by slug and by id", func(t *testing.T) {
+		byslug := callTool(t, env, token, "get_link", map[string]any{"link": "life"})
+		if byslug.IsError {
+			t.Fatalf("get by slug: %s", byslug.ErrMessage)
+		}
+		id, _ := byslug.Structured["id"].(string)
+		byid := callTool(t, env, token, "get_link", map[string]any{"link": id})
+		if byid.IsError || byid.Structured["slug"] != "life" {
+			t.Fatalf("get by id failed: %v", byid.Structured)
+		}
+	})
+
+	t.Run("partial update leaves other fields", func(t *testing.T) {
+		resp := callTool(t, env, token, "update_link", map[string]any{
+			"link": "life", "title": "Renamed",
+		})
+		if resp.IsError {
+			t.Fatalf("update: %s %s", resp.ErrCode, resp.ErrMessage)
+		}
+		if resp.Structured["title"] != "Renamed" || resp.Structured["url"] != "https://example.com/1" {
+			t.Errorf("overlay wrong: %v", resp.Structured)
+		}
+	})
+
+	t.Run("non-owner cannot update or delete", func(t *testing.T) {
+		up := callTool(t, env, otherToken, "update_link", map[string]any{"link": "life", "title": "Hax"})
+		if !up.IsError || up.ErrCode != "forbidden" {
+			t.Errorf("update: want forbidden, got %v %s", up.IsError, up.ErrCode)
+		}
+		del := callTool(t, env, otherToken, "delete_link", map[string]any{"link": "life"})
+		if !del.IsError || del.ErrCode != "forbidden" {
+			t.Errorf("delete: want forbidden, got %v %s", del.IsError, del.ErrCode)
+		}
+	})
+
+	t.Run("owner deletes", func(t *testing.T) {
+		resp := callTool(t, env, token, "delete_link", map[string]any{"link": "life"})
+		if resp.IsError {
+			t.Fatalf("delete: %s", resp.ErrMessage)
+		}
+		if resp.Structured["deleted"] != true {
+			t.Errorf("deleted = %v", resp.Structured["deleted"])
+		}
+		get := callTool(t, env, token, "get_link", map[string]any{"link": "life"})
+		if !get.IsError || get.ErrCode != "not_found" {
+			t.Errorf("after delete: want not_found, got %v %s", get.IsError, get.ErrCode)
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Tool Inventory" — share/unshare/co-owner tools.
+func TestShareAndCoOwnerTools(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "agent@example.com")
+	_, joeToken := seedUserToken(t, env, "joe@example.com")
+
+	create := callTool(t, env, token, "create_link", map[string]any{
+		"slug": "secret", "url": "https://example.com/s", "visibility": "secure",
+	})
+	if create.IsError {
+		t.Fatalf("create: %s", create.ErrMessage)
+	}
+
+	t.Run("recipient cannot read before share, can after", func(t *testing.T) {
+		before := callTool(t, env, joeToken, "get_link", map[string]any{"link": "secret"})
+		if !before.IsError || before.ErrCode != "forbidden" {
+			t.Fatalf("pre-share read: want forbidden, got %v %s", before.IsError, before.ErrCode)
+		}
+		share := callTool(t, env, token, "share_link", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if share.IsError {
+			t.Fatalf("share: %s %s", share.ErrCode, share.ErrMessage)
+		}
+		after := callTool(t, env, joeToken, "get_link", map[string]any{"link": "secret"})
+		if after.IsError {
+			t.Fatalf("post-share read: %s %s", after.ErrCode, after.ErrMessage)
+		}
+		// Share recipients don't see the share roster (owners only).
+		if _, present := after.Structured["shared_with"]; present {
+			t.Errorf("share recipient must not see the share roster")
+		}
+	})
+
+	t.Run("duplicate share rejected", func(t *testing.T) {
+		resp := callTool(t, env, token, "share_link", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if !resp.IsError || resp.ErrCode != "duplicate_share" {
+			t.Errorf("want duplicate_share, got %v %s", resp.IsError, resp.ErrCode)
+		}
+	})
+
+	t.Run("recipient cannot manage shares", func(t *testing.T) {
+		resp := callTool(t, env, joeToken, "share_link", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if !resp.IsError || resp.ErrCode != "forbidden" {
+			t.Errorf("want forbidden, got %v %s", resp.IsError, resp.ErrCode)
+		}
+	})
+
+	t.Run("unshare revokes", func(t *testing.T) {
+		resp := callTool(t, env, token, "unshare_link", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if resp.IsError {
+			t.Fatalf("unshare: %s", resp.ErrMessage)
+		}
+		read := callTool(t, env, joeToken, "get_link", map[string]any{"link": "secret"})
+		if !read.IsError || read.ErrCode != "forbidden" {
+			t.Errorf("post-unshare read: want forbidden, got %v %s", read.IsError, read.ErrCode)
+		}
+	})
+
+	t.Run("co-owner add and duplicate", func(t *testing.T) {
+		resp := callTool(t, env, token, "add_co_owner", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if resp.IsError {
+			t.Fatalf("add_co_owner: %s %s", resp.ErrCode, resp.ErrMessage)
+		}
+		owners, _ := resp.Structured["owners"].([]any)
+		if len(owners) != 2 {
+			t.Errorf("owners = %v, want 2", owners)
+		}
+		dup := callTool(t, env, token, "add_co_owner", map[string]any{"link": "secret", "email": "joe@example.com"})
+		if !dup.IsError || dup.ErrCode != "duplicate_owner" {
+			t.Errorf("want duplicate_owner, got %v %s", dup.IsError, dup.ErrCode)
+		}
+		// Co-owner can now update.
+		up := callTool(t, env, joeToken, "update_link", map[string]any{"link": "secret", "title": "Ours"})
+		if up.IsError {
+			t.Errorf("co-owner update: %s %s", up.ErrCode, up.ErrMessage)
+		}
+	})
+
+	t.Run("unknown email named", func(t *testing.T) {
+		resp := callTool(t, env, token, "share_link", map[string]any{"link": "secret", "email": "ghost@example.com"})
+		if !resp.IsError || resp.ErrCode != "unknown_user" || !strings.Contains(resp.ErrMessage, "ghost@example.com") {
+			t.Errorf("got %v %s %q", resp.IsError, resp.ErrCode, resp.ErrMessage)
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Authorization Parity with the REST API"
+// Scenario: Visibility respected in listing
+func TestListLinksFilters(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "agent@example.com")
+	_, otherToken := seedUserToken(t, env, "other@example.com")
+
+	mk := func(tok, slug, viz string, share []string) {
+		args := map[string]any{"slug": slug, "url": "https://example.com/" + slug, "visibility": viz}
+		if share != nil {
+			args["share_with"] = share
+		}
+		if resp := callTool(t, env, tok, "create_link", args); resp.IsError {
+			t.Fatalf("create %s: %s", slug, resp.ErrMessage)
+		}
+	}
+	mk(token, "mine-pub", "public", nil)
+	mk(token, "mine-priv", "private", nil)
+	mk(otherToken, "theirs-pub", "public", nil)
+	mk(otherToken, "theirs-priv", "private", nil)
+	mk(otherToken, "theirs-secure", "secure", []string{"agent@example.com"})
+
+	names := func(resp *toolResponse) map[string]bool {
+		got := map[string]bool{}
+		links, _ := resp.Structured["links"].([]any)
+		for _, l := range links {
+			m, _ := l.(map[string]any)
+			got[m["slug"].(string)] = true
+		}
+		return got
+	}
+
+	t.Run("mine", func(t *testing.T) {
+		resp := callTool(t, env, token, "list_links", map[string]any{})
+		got := names(resp)
+		if !got["mine-pub"] || !got["mine-priv"] || len(got) != 2 {
+			t.Errorf("mine = %v", got)
+		}
+	})
+
+	t.Run("shared", func(t *testing.T) {
+		resp := callTool(t, env, token, "list_links", map[string]any{"filter": "shared"})
+		got := names(resp)
+		if !got["theirs-secure"] || len(got) != 1 {
+			t.Errorf("shared = %v", got)
+		}
+	})
+
+	t.Run("public excludes others' private and secure", func(t *testing.T) {
+		resp := callTool(t, env, token, "list_links", map[string]any{"filter": "public"})
+		got := names(resp)
+		if !got["mine-pub"] || !got["theirs-pub"] {
+			t.Errorf("public missing public links: %v", got)
+		}
+		if got["theirs-priv"] || got["theirs-secure"] {
+			t.Errorf("public leaked non-public links: %v", got)
+		}
+	})
+
+	t.Run("search mine", func(t *testing.T) {
+		resp := callTool(t, env, token, "list_links", map[string]any{"q": "mine-pub"})
+		got := names(resp)
+		if !got["mine-pub"] || len(got) != 1 {
+			t.Errorf("q= results: %v", got)
+		}
+	})
+
+	t.Run("bad filter", func(t *testing.T) {
+		resp := callTool(t, env, token, "list_links", map[string]any{"filter": "everything"})
+		if !resp.IsError || resp.ErrCode != "validation_failed" {
+			t.Errorf("want validation_failed, got %v %s", resp.IsError, resp.ErrCode)
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Tool Inventory" — get_link_stats.
+func TestGetLinkStats(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "agent@example.com")
+	_, otherToken := seedUserToken(t, env, "other@example.com")
+
+	create := callTool(t, env, token, "create_link", map[string]any{"slug": "counted", "url": "https://example.com/c"})
+	if create.IsError {
+		t.Fatalf("create: %s", create.ErrMessage)
+	}
+	id, _ := create.Structured["id"].(string)
+
+	if err := env.ClickStore.RecordClick(context.Background(), store.ClickEvent{LinkID: id, Referrer: "https://news.ycombinator.com/"}); err != nil {
+		t.Fatalf("record click: %v", err)
+	}
+
+	resp := callTool(t, env, token, "get_link_stats", map[string]any{"link": "counted"})
+	if resp.IsError {
+		t.Fatalf("stats: %s %s", resp.ErrCode, resp.ErrMessage)
+	}
+	if total, _ := resp.Structured["total"].(float64); total != 1 {
+		t.Errorf("total = %v, want 1", resp.Structured["total"])
+	}
+	recent, _ := resp.Structured["recent"].([]any)
+	if len(recent) != 1 {
+		t.Fatalf("recent = %v", recent)
+	}
+	r0, _ := recent[0].(map[string]any)
+	if r0["referrer"] != "https://news.ycombinator.com/" {
+		t.Errorf("referrer = %v", r0["referrer"])
+	}
+
+	denied := callTool(t, env, otherToken, "get_link_stats", map[string]any{"link": "counted"})
+	if !denied.IsError || denied.ErrCode != "forbidden" {
+		t.Errorf("stranger stats: want forbidden, got %v %s", denied.IsError, denied.ErrCode)
+	}
+}
+
+// fakeSuggester returns canned suggestions; slug intentionally invalid in one mode.
+type fakeSuggester struct {
+	badSlug bool
+	err     error
+}
+
+func (f fakeSuggester) Suggest(ctx context.Context, req llm.SuggestRequest) (*llm.SuggestResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	slug := "suggested-slug"
+	if f.badSlug {
+		slug = "Invalid Slug!"
+	}
+	return &llm.SuggestResponse{Slug: slug, Title: "Suggested", Description: "From LLM", Tags: []string{"ai"}}, nil
+}
+
+// Governing: SPEC-0018 REQ "Conditional Suggestion Tool" + SPEC-0017 parity.
+func TestSuggestTool(t *testing.T) {
+	t.Run("maps suggestions", func(t *testing.T) {
+		env := newFullEnv(t, fakeSuggester{})
+		_, token := seedUserToken(t, env, "a@example.com")
+		resp := callTool(t, env, token, "suggest_link_metadata", map[string]any{"url": "https://example.com/page"})
+		if resp.IsError {
+			t.Fatalf("suggest: %s %s", resp.ErrCode, resp.ErrMessage)
+		}
+		if resp.Structured["slug"] != "suggested-slug" || resp.Structured["title"] != "Suggested" {
+			t.Errorf("structured = %v", resp.Structured)
+		}
+	})
+
+	t.Run("invalid slug blanked like REST", func(t *testing.T) {
+		env := newFullEnv(t, fakeSuggester{badSlug: true})
+		_, token := seedUserToken(t, env, "a@example.com")
+		resp := callTool(t, env, token, "suggest_link_metadata", map[string]any{"url": "https://example.com/page"})
+		if resp.IsError {
+			t.Fatalf("suggest: %s", resp.ErrMessage)
+		}
+		if slug, present := resp.Structured["slug"]; present && slug != "" {
+			t.Errorf("invalid slug must be blanked, got %v", slug)
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		env := newFullEnv(t, fakeSuggester{err: errors.New("boom")})
+		_, token := seedUserToken(t, env, "a@example.com")
+		resp := callTool(t, env, token, "suggest_link_metadata", map[string]any{"url": "https://example.com/page"})
+		if !resp.IsError || resp.ErrCode != "llm_error" {
+			t.Errorf("want llm_error, got %v %s", resp.IsError, resp.ErrCode)
+		}
+	})
+}
+
+// Governing: SPEC-0018 REQ "Tool Inventory" — list_keywords.
+func TestListKeywords(t *testing.T) {
+	env := newFullEnv(t, nil)
+	_, token := seedUserToken(t, env, "a@example.com")
+
+	if _, err := env.KeywordStore.Create(context.Background(), "jira", "https://jira.example.com/browse/{slug}", "Jira tickets"); err != nil {
+		t.Fatalf("seed keyword: %v", err)
+	}
+
+	resp := callTool(t, env, token, "list_keywords", map[string]any{})
+	if resp.IsError {
+		t.Fatalf("list_keywords: %s", resp.ErrMessage)
+	}
+	kws, _ := resp.Structured["keywords"].([]any)
+	if len(kws) != 1 || kws[0] != "jira" {
+		t.Errorf("keywords = %v", kws)
+	}
+}

--- a/internal/store/link_store.go
+++ b/internal/store/link_store.go
@@ -101,6 +101,86 @@ func (s *LinkStore) Create(ctx context.Context, slug, url, ownerID, title, descr
 	return s.GetByID(ctx, id)
 }
 
+// CreateFull creates a link together with its primary owner, tags, and share
+// grants in a single transaction: if any write fails, no partial link exists.
+// Tag names are deduplicated by their upserted tag ID so duplicate spellings
+// of the same tag cannot violate the link_tags primary key and roll back the
+// write. Share user IDs must be pre-resolved to existing users by the caller.
+// Governing: SPEC-0018 REQ "Database Operation Standards", ADR-0018
+func (s *LinkStore) CreateFull(ctx context.Context, slug, url, ownerID, title, description, visibility string, tagNames, shareUserIDs []string, sharedBy string) (*Link, error) {
+	// Governing: SPEC-0002 REQ "Links Table" — reject over-length title/description before insert
+	if err := ValidateLinkText(title, description); err != nil {
+		return nil, err
+	}
+	if visibility == "" {
+		visibility = "public"
+	}
+	id := uuid.New().String()
+	now := time.Now().UTC()
+
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create full link: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, tx.Rebind(`
+		INSERT INTO links (id, slug, url, title, description, visibility, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, slug, url, title, description, visibility, now, now)
+	if err != nil {
+		if isUniqueConstraintError(err) {
+			return nil, ErrSlugTaken
+		}
+		return nil, fmt.Errorf("create full link: insert link: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, tx.Rebind(`
+		INSERT INTO link_owners (link_id, user_id, is_primary, created_at) VALUES (?, ?, 1, ?)
+	`), id, ownerID, now)
+	if err != nil {
+		return nil, fmt.Errorf("create full link: insert owner: %w", err)
+	}
+
+	seenTags := make(map[string]bool, len(tagNames))
+	for _, name := range tagNames {
+		tag, err := s.tags.upsertTx(ctx, tx, name)
+		if err != nil {
+			return nil, fmt.Errorf("create full link: upsert tag %q: %w", name, err)
+		}
+		if seenTags[tag.ID] {
+			continue
+		}
+		seenTags[tag.ID] = true
+		_, err = tx.ExecContext(ctx, tx.Rebind(`
+			INSERT INTO link_tags (link_id, tag_id) VALUES (?, ?)
+		`), id, tag.ID)
+		if err != nil {
+			return nil, fmt.Errorf("create full link: insert link_tag: %w", err)
+		}
+	}
+
+	seenShares := make(map[string]bool, len(shareUserIDs))
+	for _, uid := range shareUserIDs {
+		if seenShares[uid] {
+			continue
+		}
+		seenShares[uid] = true
+		_, err = tx.ExecContext(ctx, tx.Rebind(`
+			INSERT INTO link_shares (link_id, user_id, shared_by) VALUES (?, ?, ?)
+		`), id, uid, sharedBy)
+		if err != nil {
+			return nil, fmt.Errorf("create full link: insert share: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("create full link: commit: %w", err)
+	}
+
+	return s.GetByID(ctx, id)
+}
+
 // GetBySlug returns the link matching slug, or ErrNotFound.
 // Governing: SPEC-0002 REQ "Link Store Interface" — WHEN GetBySlug called with missing slug THEN returns sentinel ErrNotFound
 func (s *LinkStore) GetBySlug(ctx context.Context, slug string) (*Link, error) {


### PR DESCRIPTION
## Summary

The SPEC-0018 v1 tool inventory — 11 tools, all thin adapters over the shared store layer (authorization is delegated, never reimplemented):

`create_link` · `get_link` · `list_links` · `update_link` · `delete_link` · `share_link` · `unshare_link` · `add_co_owner` · `get_link_stats` · `suggest_link_metadata` (LLM-gated) · `list_keywords`

Highlights:
- **Agent-safe defaults**: `create_link` defaults to `private`; `share_with` emails flip the default to `secure` — the headline "create a link and share it with me" is one tool call returning a working short URL
- **Atomic create**: new `LinkStore.CreateFull` writes link + primary owner + tags + share grants in one transaction; tag names dedupe by upserted tag ID (duplicate spellings can't roll back the write — the #198 failure mode is impossible on this path); unknown `share_with` emails fail the whole call, named, before anything is written
- **Authorization parity**: read = owner∨shared∨admin, mutate/stats/share-management = owner∨admin — the same rules and store calls as `/api/v1`; `list_links filter:public` uses `ListPublic` so other users' private/secure links can't leak
- **Short URLs**: derived per request (X-Forwarded-Proto/TLS + Host), stashed in context for tool handlers
- **Errors**: stable lowercase codes (`duplicate_slug`, `unknown_user`, `forbidden`, `validation_failed`, …) as JSON in error tool results
- Update semantics: pointer-optional fields overlay current values; slug immutable; `tags: []` clears

## Testing

24 new test cases across 7 test functions, driving the real Streamable HTTP handler over an in-memory DB: inventory exactness (with/without LLM, schemas present), private/secure defaults, share-grant round-trip incl. recipient-visibility before/after, atomicity of failed share resolution, duplicate slug/share/owner codes, validation matrix, partial-update overlay, tag-dedupe, list filters (mine/shared/public + leak check), stats with a recorded click + forbidden for strangers, suggest mapping incl. invalid-slug blanking and provider errors, keyword listing, and Prometheus counters for success+error outcomes.

`go build && go vet && golangci-lint run && go test ./...` all green.

### PR Convention
Closes #225
Part of #223 (SPEC-0018)
Implements SPEC-0018 REQ "Tool Inventory", REQ "Agent-Oriented Creation Defaults", REQ "Database Operation Standards"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Posted on behalf of `@joestump` by [Claude](https://claude.ai).
